### PR TITLE
Remove global state

### DIFF
--- a/examples/bad.ml
+++ b/examples/bad.ml
@@ -41,12 +41,25 @@ let capit () =
 let plus () =
   OUnit.assert_equal 9 (To_test.plus [1;1;2;3])
 
-let test_set = [
+let test_one = [
   "Capitalize" , `Quick, capit;
   "Add entries", `Slow , plus ;
 ]
 
+let test_two = [
+  "ok"         , `Quick, (fun () -> ());
+  "Capitalize" , `Quick, capit;
+  "ok"         , `Quick, (fun () -> ());
+]
+
 (* Run it *)
-let () =
-  try Alcotest.run ~and_exit:false "My first test" ["test_set", test_set]
+let one () =
+  try Alcotest.run ~and_exit:false "My first test" ["one", test_one]
   with Alcotest.Test_error -> Printf.printf "Continue!!\n%!"
+
+let two () =
+  Alcotest.run ~and_exit:true "Hoho" ["two", test_two]
+
+let () =
+  one ();
+  two ()

--- a/lib/alcotest.ml
+++ b/lib/alcotest.ml
@@ -32,18 +32,19 @@ let single_test fn = OUnit.TestCase fn
 (* global state *)
 type t = {
 
-  (* library options *)
+  (* library values. *)
   name : string;
   tests: single_test list;
 
+  (* caches computed from the library values. *)
   nodes: node list list;
   doc  : node list -> string option;
   speed: node list -> speed_level option;
 
-  (* runtime state *)
+  (* runtime state. *)
   mutable errors: string list;
 
-  (* runtime options *)
+  (* runtime options. *)
   max_label: int;
   max_doc  : int;
   speed_level: speed_level;

--- a/lib/alcotest.ml
+++ b/lib/alcotest.ml
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+let sp = Printf.sprintf
+
 (* Types *)
 type speed_level = [`Quick | `Slow]
 
@@ -21,19 +23,54 @@ type test_case = string * speed_level * (unit -> unit)
 
 type test = string * test_case list
 
-(* global state *)
+(* FIXME: should remove dependency to OUnit *)
+type node = OUnit.node
 
-let errors = ref []
-let docs = Hashtbl.create 16
-let speeds = Hashtbl.create 16
-let tests = ref []
-let global_name = ref (Filename.basename Sys.argv.(0))
-let max_label = ref 0
-let max_doc = ref 0
-let verbose = ref false
-let speed_level = ref `Slow
-let show_errors = ref false
-let json = ref false
+type single_test = OUnit.test
+let single_test fn = OUnit.TestCase fn
+
+(* global state *)
+type t = {
+
+  (* library options *)
+  name : string;
+  tests: single_test list;
+
+  nodes: node list list;
+  doc  : node list -> string option;
+  speed: node list -> speed_level option;
+
+  (* runtime state *)
+  mutable errors: string list;
+
+  (* runtime options *)
+  max_label: int;
+  max_doc  : int;
+  speed_level: speed_level;
+  show_errors: bool;
+  json       : bool;
+  verbose    : bool;
+  log_dir    : string;
+
+}
+
+let empty () =
+  let name = Filename.basename Sys.argv.(0) in
+  let errors = [] in
+  let nodes = [] in
+  let doc _ = None in
+  let speed _ = None in
+  let tests = [] in
+  let max_label = 0 in
+  let max_doc = 0 in
+  let verbose = false in
+  let speed_level = `Slow in
+  let show_errors = false in
+  let json = false in
+  let log_dir = Sys.getcwd () in
+  { name; errors; tests; nodes; doc; speed;
+    max_label; max_doc; speed_level;
+    show_errors; json; verbose; log_dir }
 
 let compare_speed_level s1 s2 =
   match s1, s2 with
@@ -42,18 +79,17 @@ let compare_speed_level s1 s2 =
   | `Quick, _      -> 1
   | _     , `Quick -> -1
 
-
 (* Printers *)
 
-let red fmt = Printf.sprintf ("\027[31m"^^fmt^^"\027[m")
-let green fmt = Printf.sprintf ("\027[32m"^^fmt^^"\027[m")
-let yellow fmt = Printf.sprintf ("\027[33m"^^fmt^^"\027[m")
-let blue fmt = Printf.sprintf ("\027[36m"^^fmt^^"\027[m")
+let red    fmt = sp ("\027[31m"^^fmt^^"\027[m")
+let green  fmt = sp ("\027[32m"^^fmt^^"\027[m")
+let yellow fmt = sp ("\027[33m"^^fmt^^"\027[m")
+let blue   fmt = sp ("\027[36m"^^fmt^^"\027[m")
 
-let red_s = red "%s"
-let green_s = green "%s"
+let red_s    = red "%s"
+let green_s  = green "%s"
 let yellow_s = yellow "%s"
-let blue_s = blue "%s"
+let blue_s   = blue "%s"
 
 let with_process_in cmd f =
   let ic = Unix.open_process_in cmd in
@@ -68,7 +104,7 @@ let dup oc =
 
 let terminal_columns =
   let split s c =
-    Re_str.split (Re_str.regexp (Printf.sprintf "[%c]" c)) s in
+    Re_str.split (Re_str.regexp (sp "[%c]" c)) s in
   try           (* terminfo *)
     with_process_in "tput cols"
       (fun ic -> int_of_string (input_line ic))
@@ -104,19 +140,19 @@ let indent_right s nb =
   else
     String.make nb ' ' ^ s
 
-let left_column () =
-  !max_label + !max_doc + 16
+let left_column t =
+  t.max_label + t.max_doc + 16
 
-let right_column () =
+let right_column t =
   terminal_columns
-  - left_column ()
+  - left_column t
   + 15
 
-let right s =
-  if not !json then Printf.printf "%s\n%!" (indent_right s (right_column ()))
+let right t s =
+  if not t.json then Printf.printf "%s\n%!" (indent_right s (right_column t))
 
-let left s =
-  if not !json then Printf.printf "%s%!" (indent_left s (left_column ()))
+let left t s =
+  if not t.json then Printf.printf "%s%!" (indent_left s (left_column t))
 
 let string_of_channel ic =
   let n = 32768 in
@@ -133,48 +169,50 @@ let string_of_channel ic =
   iter ic b s;
   Buffer.contents b
 
-let log_dir = ref (Sys.getcwd ())
-
 let file_of_path path ext =
   let path = List.tl (List.rev path) in
-  Printf.sprintf "%s.%s" (String.concat "-" (List.map OUnit.string_of_node path)) ext
+  sp "%s.%s" (String.concat "-" (List.map OUnit.string_of_node path)) ext
 
-let output_file path =
-  Filename.concat !log_dir (file_of_path path "output")
+let output_file t path =
+  Filename.concat t.log_dir (file_of_path path "output")
 
-let prepare () =
-  if not (Sys.file_exists !log_dir) then Unix.mkdir !log_dir 0o755
+let prepare t =
+  if not (Sys.file_exists t.log_dir) then Unix.mkdir t.log_dir 0o755
 
-let string_of_node = function
-  | OUnit.ListItem i -> Printf.sprintf "%3d" i
-  | OUnit.Label l    -> indent_left (Printf.sprintf "%s" (blue_s l)) (!max_label+8)
+let string_of_node t = function
+  | OUnit.ListItem i -> sp "%3d" i
+  | OUnit.Label l    -> indent_left (sp "%s" (blue_s l)) (t.max_label+8)
 
-let string_of_path path =
+let string_of_path t path =
   let rec aux = function
     | []   -> "--"
     | OUnit.ListItem _ :: t -> aux t
-    | h::t -> string_of_node h ^ String.concat " " (List.map string_of_node t) in
+    | h::r ->
+      string_of_node t h ^ String.concat " " (List.map (string_of_node t) r)
+  in
   aux (List.rev path)
 
-let doc_of_path path =
+let doc_of_path t path =
   let path = List.rev (List.tl (List.rev path)) in
-  try Hashtbl.find docs path
-  with Not_found -> ""
+  match t.doc path with
+  | None   -> ""
+  | Some d -> d
 
-let speed_of_path path =
+let speed_of_path t path =
   let path = List.rev (List.tl (List.rev path)) in
-  try Hashtbl.find speeds path
-  with Not_found -> `Slow
+  match t.speed path with
+  | None   -> `Slow
+  | Some s -> s
 
 let short_string_of_path path =
   let path = List.rev (List.tl (List.rev path)) in
   OUnit.string_of_path path
 
-let eprintf fmt =
-  Printf.ksprintf (fun str -> if not !json then Printf.eprintf "%s" str) fmt
+let eprintf t fmt =
+  Printf.ksprintf (fun str -> if not t.json then Printf.eprintf "%s" str) fmt
 
-let error path fmt =
-  let filename = output_file path in
+let error t path fmt =
+  let filename = output_file t path in
   let output =
     if not (Sys.file_exists filename) then "--"
     else
@@ -183,27 +221,27 @@ let error path fmt =
       close_in file;
       output
   in
-  right (red "[ERROR]");
+  right t (red "[ERROR]");
   Printf.kprintf (fun str ->
       let error =
-        Printf.sprintf "%s\n%s\n%s:\n%s\n%s\n"
+        sp "%s\n%s\n%s:\n%s\n%s\n"
           (red "-- %s Failed --" (short_string_of_path path))
-          (doc_of_path path)
+          (doc_of_path t path)
           filename output str in
-      errors := error :: !errors
+      t.errors <- error :: t.errors
     ) fmt
 
-let print_result = function
-  | OUnit.RSuccess p     -> right (green "[OK]")
-  | OUnit.RFailure (p,s) -> error p "Failure: %s" s
-  | OUnit.RError (p, s)  -> error p "%s" s
-  | OUnit.RSkip _        -> right (yellow "[SKIP]")
-  | OUnit.RTodo _        -> right (yellow "[TODO]")
+let print_result t = function
+  | OUnit.RSuccess p     -> right t (green "[OK]")
+  | OUnit.RFailure (p,s) -> error t p "Failure: %s" s
+  | OUnit.RError (p, s)  -> error t p "%s" s
+  | OUnit.RSkip _        -> right t (yellow "[SKIP]")
+  | OUnit.RTodo _        -> right t (yellow "[TODO]")
 
-let print_event = function
+let print_event t = function
   | OUnit.EStart p  ->
-    left (Printf.sprintf "%s   %s" (string_of_path p) (doc_of_path p))
-  | OUnit.EResult r -> print_result r
+    left t (sp "%s   %s" (string_of_path t p) (doc_of_path t p))
+  | OUnit.EResult r -> print_result t r
   | OUnit.EEnd p    -> ()
 
 let failure = function
@@ -305,24 +343,26 @@ let filter_tests ~subst labels tests =
     ) [] tests in
   List.rev tests
 
-let redirect_test_output labels test_fun =
-  if !verbose then test_fun
+let redirect_test_output t labels test_fun =
+  if t.verbose then test_fun
   else fun () ->
-    let output_file = output_file labels in
+    let output_file = output_file t labels in
     with_redirect stdout output_file (fun () ->
         with_redirect stderr output_file (fun () ->
             try test_fun ()
             with exn -> begin
-                eprintf "\nTest error: %s\n" (Printexc.to_string exn);
+                eprintf t "\nTest error: %s\n" (Printexc.to_string exn);
                 Printexc.print_backtrace stderr;
                 raise exn
               end
           )
       )
 
-let select_speed labels test_fun =
-  if compare_speed_level (speed_of_path labels) !speed_level >= 0 then test_fun
-  else skip_fun
+let select_speed t labels test_fun =
+  if compare_speed_level (speed_of_path t labels) t.speed_level >= 0 then
+    test_fun
+  else
+    skip_fun
 
 type result = {
   success: int;
@@ -332,61 +372,72 @@ type result = {
 
 (* Return the json for the api, dirty out, to avoid new dependencies *)
 let json_of_result r =
-  Printf.sprintf "{\"sucess\":%i,\"failures\":%i,\"time\":%f}"
-    r.success r.failures r.time
+  sp "{\"sucess\":%i,\"failures\":%i,\"time\":%f}" r.success r.failures r.time
 
 let s = function 0 | 1 -> "" | _ -> "s"
 
-let show_result result =
+let show_result t result =
   (* Function to display errors for each test *)
   let display_errors () = match result.failures with
     | 0 -> ()
     | _ ->
-      if !verbose || !show_errors || result.success = 1 then
-        List.iter (fun error -> Printf.printf "%s\n" error) (List.rev !errors)
+      if t.verbose || t.show_errors || result.success = 1 then
+        List.iter (fun error -> Printf.printf "%s\n" error) (List.rev t.errors)
   in
-  match !json with
+  match t.json with
   | true  -> Printf.printf "%s\n" (json_of_result result)
   | false ->
     display_errors ();
     let msg = match result.failures with
       | 0 -> green "Test Successful"
-      | n -> red_s (Printf.sprintf "%d error%s!" n (s n))
+      | n -> red_s (sp "%d error%s!" n (s n))
     in
     Printf.printf "%s in %.3fs. %d test%s run.\n%!"
       msg result.time result.success (s result.success)
 
-let result test =
-  prepare ();
+let result t test =
+  prepare t;
   let start_time = Sys.time () in
-  let test = map_test redirect_test_output test in
-  let test = map_test select_speed test in
-  let results = OUnit.perform_test print_event test in
+  let test = map_test (redirect_test_output t) test in
+  let test = map_test (select_speed t) test in
+  let results = OUnit.perform_test (print_event t) test in
   let time = Sys.time () -. start_time in
   let success = List.length (List.filter has_run results) in
   let failures = List.filter failure results in
   { time; success; failures = List.length failures }
 
-let list_tests () =
-  let list = Hashtbl.fold (fun k v l -> (k,v) :: l) docs [] in
-  let list = List.sort (fun (x,_) (y,_) -> compare (List.rev x) (List.rev y)) list in
-  List.iter (fun (path, doc) ->
-      Printf.printf "%s    %s\n" (string_of_path path) doc
-    ) list
+let list_tests t =
+  let nodes = List.sort (fun x y -> compare (List.rev x) (List.rev y)) t.nodes in
+  List.iter (fun path ->
+      Printf.printf "%s    %s\n" (string_of_path t path) (doc_of_path t path)
+    ) nodes
 
-let register name (ts:test_case list) =
-  let ts = List.mapi (fun i (doc, speed, t) ->
+let register t name (ts:test_case list) =
+  let nodes = Hashtbl.create 16 in
+  let docs = Hashtbl.create 16 in
+  let speeds = Hashtbl.create 16 in
+  let max_label = ref t.max_label in
+  let max_doc = ref t.max_doc in
+  let ts = List.mapi (fun i (doc, speed, test) ->
       max_label := max !max_label (String.length name);
-      max_doc := max !max_doc (String.length doc);
+      max_doc   := max !max_doc (String.length doc);
       let path = [ OUnit.ListItem i; OUnit.Label name ] in
       let doc =
         if doc.[String.length doc - 1] = '.' then doc
         else doc ^ "." in
+      Hashtbl.add nodes path true;
       Hashtbl.add docs path doc;
       Hashtbl.add speeds path speed;
-      OUnit.TestCase t
+      OUnit.TestCase test
     ) ts in
-  tests := !tests @ [ OUnit.TestLabel (name, OUnit.TestList ts) ]
+  let tests = t.tests @ [ OUnit.TestLabel (name, OUnit.TestList ts) ] in
+  let nodes = Hashtbl.fold (fun k _ acc -> k :: acc) nodes [] in
+  let nodes = t.nodes @ List.rev nodes in
+  let doc p = try Some (Hashtbl.find docs p) with Not_found -> t.doc p in
+  let speed p = try Some (Hashtbl.find speeds p) with Not_found -> t.speed p in
+  let max_label = !max_label in
+  let max_doc = !max_doc in
+  { t with nodes; tests; doc; speed; max_label; max_doc }
 
 exception Test_error
 
@@ -396,31 +447,27 @@ let bool_of_env name =
     | _ -> true
   with Not_found -> false
 
-let run_registred_tests dir verb err quick json_f =
-  verbose     := verb;
-  log_dir     := dir;
-  speed_level := (if quick then `Quick else `Slow);
-  json        := json_f;
-  show_errors := err || bool_of_env "ALCOTEST_SHOW_ERRORS";
-  let tests = OUnit.TestList !tests in
-  let result = result tests in
-  show_result result;
+let apply fn t log_dir verbose show_errors quick json =
+  let show_errors = show_errors || bool_of_env "ALCOTEST_SHOW_ERRORS" in
+  let speed_level = if quick then `Quick else `Slow in
+  let t = { t with verbose; log_dir; json; show_errors; speed_level } in
+  fn t
+
+let run_registred_tests t =
+  let tests = OUnit.TestList t.tests in
+  let result = result t tests in
+  show_result t result;
   if result.failures > 0 then raise Test_error
 
-let run_subtest dir verb err quick json_f labels =
-  verbose     := verb;
-  log_dir     := dir;
-  speed_level := (if quick then `Quick else `Slow);
-  json        := json_f;
-  show_errors := err || bool_of_env "ALCOTEST_SHOW_ERRORS";
-  let is_empty = filter_tests ~subst:false labels !tests = [] in
+let run_subtest t labels =
+  let is_empty = filter_tests ~subst:false labels t.tests = [] in
   if is_empty then (
     Printf.printf "%s\n" (red "Invalid request!"); exit 1
   ) else
-    let tests = filter_tests ~subst:true labels !tests in
+    let tests = filter_tests ~subst:true labels t.tests in
     let tests = OUnit.TestList tests in
-    let result = result tests in
-    show_result result;
+    let result = result t tests in
+    show_result t result;
     if result.failures > 0 then raise Test_error
 
 open Cmdliner
@@ -446,30 +493,33 @@ let quicktests =
   let doc = "Run only the quick tests." in
   Arg.(value & flag & info ["q"; "quick-tests"] ~docv:"" ~doc)
 
-let default_cmd =
-  let doc = "Run all the tests." in
-  Term.(pure run_registred_tests
-        $ test_dir $ verbose $ show_errors $ quicktests $ json),
-  Term.info !global_name ~version:Alcotest_version.current ~doc
+let of_env t =
+  Term.(pure (apply (fun t -> t) t)
+        $ test_dir $ verbose $ show_errors $ quicktests $ json)
 
-let test_cmd =
+let default_cmd t =
+  let doc = "Run all the tests." in
+  Term.(pure run_registred_tests $ of_env t),
+  Term.info t.name ~version:Alcotest_version.current ~doc
+
+let test_cmd t =
   let doc = "Run a given test." in
-  let test =
+  let label =
     let doc = "The list of labels identifying a subsets of the tests to run" in
-    Arg.(value & pos_all string [] & info [] ~doc ~docv:"LABEL") in
-  Term.(pure run_subtest
-        $ test_dir $ verbose $ show_errors $ quicktests $ json $ test),
+    Arg.(value & pos_all string [] & info [] ~doc ~docv:"LABEL")
+  in
+  Term.(pure run_subtest $ of_env t $ label),
   Term.info "test" ~doc
 
-let list_cmd =
+let list_cmd t =
   let doc = "List all available tests." in
-  Term.(pure list_tests $ pure ()),
+  Term.(pure list_tests $ of_env t),
   Term.info "list" ~doc
 
 let run ?(and_exit = true) name (tl:test list) =
-  global_name := name;
-  List.iter (fun (name, tests) -> register name tests) tl;
+  let t = empty () in
+  let t = List.fold_left (fun t (name, tests) -> register t name tests) t tl in
   let err = Format.formatter_of_buffer (Buffer.create 10) in
-  match Term.eval_choice ~err default_cmd [list_cmd; test_cmd] with
+  match Term.eval_choice ~err (default_cmd t) [list_cmd t; test_cmd t] with
   | `Error _ -> if and_exit then exit 1 else raise Test_error
   | _        -> if and_exit then exit 0 else ()

--- a/lib/alcotest.mli
+++ b/lib/alcotest.mli
@@ -26,16 +26,6 @@ type test_case = string * speed_level * (unit -> unit)
 type test = string * test_case list
 (** A test has a name and contains a list of test cases *)
 
-type result = {
-  success: int;
-  failures: int;
-  time: float
-}
-(** The type for result values. *)
-
-val result: OUnit.test -> result
-(** Run the tests, return a result. *)
-
 exception Test_error
 (** The exception return by {!run} in case of errors. *)
 


### PR DESCRIPTION
Maybe we still want to keep a global counter for the number of errors ... not totally clear to me how we should use and compose these runs.