### PR TITLE
Alcotest.check: flush formatter

### DIFF
--- a/lib/alcotest.ml
+++ b/lib/alcotest.ml
@@ -554,6 +554,7 @@ let check (type a) (module T: TESTABLE with type t = a) msg x y =
     let buf = Buffer.create 20 in
     let fmt = Format.formatter_of_buffer buf in
     Format.fprintf fmt "Error %s: expecting %a, got %a." msg T.pp x T.pp y;
+    Format.pp_print_flush fmt ();
     failwith (Buffer.contents buf)
   )
 


### PR DESCRIPTION
otherwise the error message isn't actually displayed (on OCaml 4.02.2)

Previously a test I wrote failed with this rather uniformative output:
```
--------------------------------------------------------------------------------------------------------------------------------------------------------------
ASSERT same file kind
--------------------------------------------------------------------------------------------------------------------------------------------------------------

[failure] 
```

Now it fails with:
```
--------------------------------------------------------------------------------------------------------------------------------------------------------------
ASSERT same file kind
--------------------------------------------------------------------------------------------------------------------------------------------------------------

[failure] Error same file kind: expecting regular file, got directory.
```