### PR TITLE
Result file names

### DIFF
--- a/lib/alcotest.ml
+++ b/lib/alcotest.ml
@@ -163,7 +163,7 @@ let string_of_channel ic =
   iter ic b s;
   Buffer.contents b
 
-let short_string_of_path (Path (n, i)) = sp "%s.%3d" n i
+let short_string_of_path (Path (n, i)) = sp "%s.%03d" n i
 let file_of_path path ext = sp "%s.%s" (short_string_of_path path) ext
 let output_file t path = Filename.concat t.log_dir (file_of_path path "output")
 


### PR DESCRIPTION
This patchset fixes a couple result file naming issues that have been bothering me.

First, 999a935 zero-pads the numbers in the result file names so they don't have spaces in their names which is ugly/annoying (more typing in shell for escape characters).

Then, 32cfc7b introduces best-effort alias symlink creation from `[Suite].[doc].output` to `[Suite].[00n].output`. Colliding/old files are first removed. if symlink creation fails, alcotest fails. If two tests have the same doc string, the last one to write wins. If the doc string contains bad characters, those are carried into the alias file name.

This feature is useful when each of your tests has a directory or collection of files used during the test and the doc string is reused to identify the test and to identify the resources the test uses. If it contains human-readable documentation, this is less useful.

Due to the ambiguous meaning of the doc string, I'm not sure if this design is the correct one. I certainly find it helpful but maybe the interface needs to be expanded slightly for general use. Feel free to cherry-pick the zero-padding and leave the alias generation, of course.