### PR TITLE
add missing newline to verbose output

### DIFF
--- a/lib/alcotest.ml
+++ b/lib/alcotest.ml
@@ -219,7 +219,8 @@ let print_result t p = function
   | `Todo _        -> print t (left (yellow "[TODO]") left_c); print_info t p
 
 let print_event t = function
-  | `Start p       -> print t (left (yellow " ...") left_c); print_info t p
+  | `Start p       -> print t (left (yellow " ...") left_c); print_info t p;
+                      if t.verbose then newline t
   | `Result (p, r) -> reset t; print_result t p r; newline t
 
 let failure: run_result -> bool = function


### PR DESCRIPTION
The first dashed line for a test case starts on the same line as the start event. This adds the newline to fix that.