### PR TITLE
Fix typo in -o option specification

### DIFF
--- a/lib/alcotest.ml
+++ b/lib/alcotest.ml
@@ -454,7 +454,7 @@ let json =
 
 let test_dir =
   let doc = "Where to store the log files of the tests." in
-  Arg.(value & opt string "./_tests/"  & info ["-o"] ~docv:"DIR" ~doc)
+  Arg.(value & opt string "./_tests/"  & info ["o"] ~docv:"DIR" ~doc)
 
 let verbose =
   let doc = "Display the test outputs." in


### PR DESCRIPTION
Without this fix, the `-o` option looks like:

    ---o=DIR (absent=./_tests/)

with it:

    -o DIR (absent=./_tests/)