### PR TITLE
Change list TESTABLE

### DIFF
--- a/lib/alcotest.ml
+++ b/lib/alcotest.ml
@@ -553,7 +553,8 @@ let list (type a) elt =
         pp_sep ppf ();
         pp_print_list ~pp_sep pp_v ppf vs
     let pp = pp_print_list Elt.pp
-    let equal = (=)
+    let equal l1 l2 = 
+      List.length l1 = List.length l2 && List.for_all2 (Elt.equal) l1 l2
   end in
   (module M: TESTABLE with type t = M.t)
 


### PR DESCRIPTION
Changed list TESTABLE to use the equality of the underlying element, which is necessary for cases when (=) does not work (e.g. Cstruct list)