### PR TITLE
Fix check_raises

### DIFF
--- a/lib/alcotest.ml
+++ b/lib/alcotest.ml
@@ -632,10 +632,13 @@ let fail msg =
   show_line msg;
   check_err "Error %s." msg
 
+let collect_exception f =
+  try f (); None with e -> Some e
+
 let check_raises msg exn f =
   show_line msg;
-  try
-    f ();
+  match collect_exception f with
+    None -> 
     check_err "Fail %s: expecting %s, got nothing." msg (Printexc.to_string exn)
-  with e ->
+  | Some e ->
     ()

--- a/lib/alcotest.ml
+++ b/lib/alcotest.ml
@@ -641,4 +641,6 @@ let check_raises msg exn f =
     None -> 
     check_err "Fail %s: expecting %s, got nothing." msg (Printexc.to_string exn)
   | Some e ->
-    ()
+    if e <> exn then
+      check_err "Fail %s: expecting %s, got %s."
+        msg (Printexc.to_string exn) (Printexc.to_string e)


### PR DESCRIPTION
Before:

```
# Alcotest.check_raises "blah" Not_found (fun () -> ());;
-------------------------------------------------------------------------------------
ASSERT blah
-------------------------------------------------------------------------------------
- : unit = ()

```

After:

```
# Alcotest.check_raises "blah" Not_found (fun () -> ());;
-------------------------------------------------------------------------------------
ASSERT blah
-------------------------------------------------------------------------------------
Exception:
Alcotest.Check_error "Fail blah: expecting Not_found, got nothing.".
# Alcotest.check_raises "blah" Not_found (fun () -> invalid_arg "");;
-------------------------------------------------------------------------------------
ASSERT blah
-------------------------------------------------------------------------------------
Exception:
Alcotest.Check_error
 "Fail blah: expecting Not_found, got Invalid_argument(\\\"\\\").".
# Alcotest.check_raises "blah" Not_found (fun () -> raise Not_found);;
-------------------------------------------------------------------------------------
ASSERT blah
-------------------------------------------------------------------------------------
- : unit = ()
```
