### PR TITLE
pass: add a testable that always passes

### DIFF
--- a/lib/alcotest.ml
+++ b/lib/alcotest.ml
@@ -598,6 +598,14 @@ let result (type a) (type e) a e =
   end in
   (module M: TESTABLE with type t = M.t)
 
+let pass (type a) =
+  let module M = struct
+    type t = a
+    let pp fmt _ = Format.pp_print_string fmt "Alcotest.pass"
+    let equal _ _ = true
+  end in
+  (module M: TESTABLE with type t = M.t)
+
 let show_line msg =
   if !quiet then ()
   else (

--- a/lib/alcotest.mli
+++ b/lib/alcotest.mli
@@ -92,6 +92,9 @@ val of_pp: (Format.formatter -> 'a -> unit) -> 'a testable
 (** [of_pp pp] tests values which can be printed using [pp] and
     compared using {!Pervasives.compare} *)
 
+val pass: 'a testable
+(** [pass] tests values of any type and always succeeds. *)
+
 val check: 'a testable -> string -> 'a -> 'a -> unit
 (** Check that two values are equal. *)
 


### PR DESCRIPTION
Use pass to disregard components of data types you are testing. For example, if you want to test that a pair-valued function, but disregard its second component for the in the test, you can use the following:

```ocaml
Alcotest.(pair int pass)
```