### PR TITLE
revert ignoring warning 3, use Astring uppercase instead of String/Char

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ setup.ml: _oasis
 	rm -f _tags myocamlbuild.ml
 	oasis setup
 	echo 'true: debug, bin_annot' >> _tags
-	echo 'true: warn_error(+1..49-3), warn(A-4-41-44)' >> _tags
+	echo 'true: warn_error(+1..49), warn(A-4-41-44)' >> _tags
 #	echo 'Ocamlbuild_plugin.mark_tag_used "tests"' >> myocamlbuild.ml
 
 doc: setup.data build

--- a/examples/bad.ml
+++ b/examples/bad.ml
@@ -30,7 +30,7 @@ For more information, please refer to <http://unlicense.org/>
 
 (* A module with functions to test *)
 module To_test = struct
-  let capit letter = String.uppercase letter
+  let capit letter = Astring.String.Ascii.uppercase letter
   let plus int_list = List.map (fun a -> a + a) int_list
 end
 

--- a/examples/simple.ml
+++ b/examples/simple.ml
@@ -30,7 +30,7 @@ For more information, please refer to <http://unlicense.org/>
 
 (* A module with functions to test *)
 module To_test = struct
-  let capit letter = Char.uppercase letter
+  let capit letter = Astring.Char.Ascii.uppercase letter
   let plus int_list = List.fold_left (fun a b -> a + b) 0 int_list
 end
 


### PR DESCRIPTION
@samoht this works with ocaml 4.02 and 4.03, by using the (already required) Astring functions instead of the OCaml stdlib ones