### PR TITLE
Add an optionnal argument `arg`

### DIFF
--- a/lib/alcotest.ml
+++ b/lib/alcotest.ml
@@ -503,11 +503,11 @@ let list_cmd t =
   Term.(pure list_tests $ of_env t $ set_color),
   Term.info "list" ~doc
 
-let run ?(and_exit = true) name (tl:test list) =
+let run ?(and_exit = true) ?argv name (tl:test list) =
   Fmt.(pf stdout) "Testing %a.\n" bold_s name;
   let t = empty () in
   let t = List.fold_left (fun t (name, tests) -> register t name tests) t tl in
-  match Term.eval_choice (default_cmd t) [list_cmd t; test_cmd t] with
+  match Term.eval_choice ?argv (default_cmd t) [list_cmd t; test_cmd t] with
   | `Ok 0    -> if and_exit then exit 0 else ()
   | `Error _ -> if and_exit then exit 1 else raise Test_error
   | `Ok i    -> if and_exit then exit i else raise Test_error

--- a/lib/alcotest.mli
+++ b/lib/alcotest.mli
@@ -35,7 +35,9 @@ val run: ?and_exit:bool -> ?argv:string array -> string -> test list -> unit
     happens when the function ends. By default, [and_exit] is set,
     which makes the function exit with [0] if everything is fine or
     [1] if there is an issue. If [and_exit] is [false], then the
-    function raises [Test_error] on error. *)
+    function raises [Test_error] on error. The optional argument
+    [argv] specify the argument send to alcotest like ["--json"],
+    ["--verbose"], etc. (require at least one argument).*)
 
 (** {2 Assert functions} *)
 

--- a/lib/alcotest.mli
+++ b/lib/alcotest.mli
@@ -29,7 +29,7 @@ type test = string * test_case list
 exception Test_error
 (** The exception return by {!run} in case of errors. *)
 
-val run: ?and_exit:bool -> string -> test list -> unit
+val run: ?and_exit:bool -> ?argv:string array -> string -> test list -> unit
 (** [run n t] runs the test suite [t]. [n] is is the name of the
     tested library. The optional argument [and_exit] controls what
     happens when the function ends. By default, [and_exit] is set,


### PR DESCRIPTION
It's useful when you try to use `Cmdliner`in top of `Alcotest`.