### PR TITLE
Add reject test that always fails

### DIFF
--- a/lib/alcotest.ml
+++ b/lib/alcotest.ml
@@ -628,6 +628,14 @@ let pass (type a) =
   end in
   (module M: TESTABLE with type t = M.t)
 
+let reject (type a) =
+  let module M = struct
+    type t = a
+    let pp fmt _ = Format.pp_print_string fmt "Alcotest.reject"
+    let equal _ _ = false
+  end in
+  (module M: TESTABLE with type t = M.t)
+
 let show_line msg =
   if !quiet then ()
   else (

--- a/lib/alcotest.mli
+++ b/lib/alcotest.mli
@@ -90,6 +90,9 @@ val of_pp: (Format.formatter -> 'a -> unit) -> 'a testable
 val pass: 'a testable
 (** [pass] tests values of any type and always succeeds. *)
 
+val reject: 'a testable
+(** [reject] tests values of any type and always fails. *)
+
 val check: 'a testable -> string -> 'a -> 'a -> unit
 (** Check that two values are equal. *)
 


### PR DESCRIPTION
When testing a variant (e.g. `result`), you need to pass a test for the other option. Using `pass` there looks wrong.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>