### PR TITLE
Print lists with Fmt.Dump.list

### DIFF
--- a/lib/alcotest.ml
+++ b/lib/alcotest.ml
@@ -557,14 +557,7 @@ let list (type a) elt =
   let (module Elt: TESTABLE with type t = a) = elt in
   let module M = struct
     type t = a list
-    let rec pp_print_list ?(pp_sep = Format.pp_print_cut) pp_v ppf = function
-      | [] -> ()
-      | [v] -> pp_v ppf v
-      | v :: vs ->
-        pp_v ppf v;
-        pp_sep ppf ();
-        pp_print_list ~pp_sep pp_v ppf vs
-    let pp = pp_print_list Elt.pp
+    let pp = Fmt.Dump.list Elt.pp
     let equal l1 l2 =
       List.length l1 = List.length l2 && List.for_all2 (Elt.equal) l1 l2
   end in


### PR DESCRIPTION
Before, it tended to squash things together (e.g. `abc` instead of `[a; b; c]`), which made test failures hard to read.

Fixes #53.

Signed-off-by: Thomas Leonard <thomas.leonard@docker.com>