### PR TITLE
Format "got" and "expected" values in the same way

### DIFF
--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -622,7 +622,7 @@ let check_err fmt = Format.ksprintf (fun err -> raise (Check_error err)) fmt
 let check t msg x y =
   show_line msg;
   if not (equal t x y) then
-    Fmt.strf "Error %s: expecting %a, got %a." msg (pp t) x (pp t) y
+    Fmt.strf "Error %s: expecting@\n%a, got@\n%a." msg (pp t) x (pp t) y
     |> failwith
 
 let fail msg =


### PR DESCRIPTION
Before, Alcotest would print differences like this:

    [failure] Error foo: expecting Ok
                                     (xxx,
                                      xxx), got
    Ok
      (xxx xxx).

It's hard to compare them like this. Instead, start a new line for both
values.