### PR TITLE
Allowed passing absolute error to Alcotest.float

### DIFF
--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -543,7 +543,7 @@ let int64 = testable Fmt.int64 (=)
 
 let int = testable Fmt.int (=)
 
-let float = testable Fmt.float (=)
+let float eps = testable Fmt.float (fun x y -> abs_float (x -. y) < eps)
 
 let char = testable Fmt.char (=)
 

--- a/src/alcotest.mli
+++ b/src/alcotest.mli
@@ -94,8 +94,8 @@ val int32: int32 testable
 val int64: int64 testable
 (** [int64] tests 64-bit integers. *)
 
-val float: float testable
-(** [float] tests floats. *)
+val float: float -> float testable
+(** [float] tests floats with specified absolute error. *)
 
 val char: char testable
 (** [char] tests characters. *)


### PR DESCRIPTION
Due to approximate nature of floats direct equality is rarely useful in practice. This PR adds a basic form approximate equality: "equal up to an absolute error".

There is one more step we can take to make testing floating point code with Alcotest a breeze: generalize `Alcotest.float` to support support relative error and "equal up to [ULP](](https://en.wikipedia.org/wiki/Unit_in_the_last_place))" via polymorphic variants, e.g.

```ocaml
Alcotest.float (`Ulp 1)
Alcotest.float (`Abs 1)
Alcotest.float (`Rel 1)
```

What do you think?