### PR TITLE
Partially revert ac7e79865a66d6926c03d3e3f25099dc5df395ff

### DIFF
--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -41,8 +41,6 @@ let test_case n s f = (n, s, f)
 
 type test = string * test_case list
 
-let test n ts = (n, ts)
-
 let quiet = ref false
 
 (* global state *)

--- a/src/alcotest.mli
+++ b/src/alcotest.mli
@@ -43,9 +43,6 @@ val test_case: string -> speed_level -> (unit -> unit) -> test_case
 type test = string * test_case list
 (** A test is an US-ASCII encoded name and a list of test cases. *)
 
-val test: string -> test_case list -> test
-(** [test n ts] is the test [n] with test cases [ts]. *)
-
 exception Test_error
 (** The exception return by {!run} in case of errors. *)
 


### PR DESCRIPTION
This is breaking backward compatibility for a lot of packages as people seem to
like using `let test = ... in Alcotest.(check .... test ...)`