### PR TITLE
Use <= instead of < in float combinator

### DIFF
--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -552,7 +552,7 @@ let int64 = testable Fmt.int64 (=)
 
 let int = testable Fmt.int (=)
 
-let float eps = testable Fmt.float (fun x y -> abs_float (x -. y) < eps)
+let float eps = testable Fmt.float (fun x y -> abs_float (x -. y) <= eps)
 
 let char = testable Fmt.char (=)
 


### PR DESCRIPTION
This allows to use `float 0.` for exact equality. Fix #106