### PR TITLE
Show one failure when multiple tests fail

### DIFF
--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -367,8 +367,12 @@ let show_result t result =
   let display_errors () = match result.failures with
     | 0 -> ()
     | _ ->
-      if t.verbose || t.show_errors || result.failures = 1 then
-        List.iter (fun error -> Printf.printf "%s\n" error) (List.rev t.errors)
+      if result.failures > 0 then
+        let print_error error = Printf.printf "%s\n" error in
+        if t.verbose || t.show_errors then
+          List.iter print_error (List.rev t.errors)
+        else
+          print_error (List.hd (List.rev t.errors))
   in
   match t.json with
   | true  -> Printf.printf "%s\n" (json_of_result result)


### PR DESCRIPTION
This PR changes the behavior of Alcotest, so that without `--show-errors` and `--verbose`, if there are any failures, the first failure is printed to standard output.

In current Alcotest, if one test fails, Alcotest shows the failure. However, if multiple tests fail, they are written to some log, which is difficult to use. Standard output receives only a list of names of the
failed tests.

Also in current Alcotest, the `--show-errors` and `--verbose` flags cause all the failures to be printed to standard output. However, this can be overwhelming if a large number of tests fail. Worse, in a progressive test suite, the first failure is the most relevant, so it would be nice if it was printed last. Then, the interactive user wouldn't have to scroll up through the entire failure list to find it. However, Alcotest prints the failures in order, so it is the last, and least relevant, failure which appears last.

Here is an example of the new output when multiple tests fail:

```
Testing parser.
[OK]                basic          0   empty.
[OK]                basic          1   space.
[OK]                basic          2   two spaces.
[ERROR]             basic          3   word.
[ERROR]             basic          4   two words.
[ERROR]             basic          5   newline.
[ERROR]             basic          6   two paragraphs.
[ERROR]             basic          7   leading whitespace.
[ERROR]             basic          8   trailing whitespace.
-- basic.003 [word.] Failed --
in _build/_tests/basic.003.output:
--------------------------------------------------------------------------------
ASSERT document tree is correct
--------------------------------------------------------------------------------
[failure] Error document tree is correct: expecting
Ok ((paragraph ((word foo)))), got
Ok ().
Raised at file "pervasives.ml", line 32, characters 22-33
Called from file "src/alcotest.ml", line 269, characters 8-14


The full test results are available in `_build/_tests`.
6 errors! in 0.002s. 9 tests run.
```