### PR TITLE
Improve documentation on test case filtering and flush error formatter on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ $ ./simple.native
 Test Successful in 0.001s. 2 tests run.
 ```
 
-You can filter which tests to run by exact name and/or test case number:
+You can filter which tests to run by supplying either the exact test name
+(which would run all testcases with that name), or the exact test name
+and test case number (which would run just that single test):
 ```shell
 $ ./simple.native test test_set
 Testing My first test.
@@ -72,6 +74,9 @@ Testing My first test.
 The full test results are available in `_build/_tests`.
 Test Successful in 0.000s. 1 test run.
 ```
+
+Note that you cannot filter by test case name (i.e. `Capitalize` or `Add entries`), you have to use
+the test case number instead.
 
 See the [examples](https://github.com/mirage/alcotest/tree/master/examples)
 folder for more examples.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ $ ./simple.native
 Test Successful in 0.001s. 2 tests run.
 ```
 
+You can filter which tests to run by exact name and/or test case number:
+```shell
+$ ./simple.native test test_set
+Testing My first test.
+[OK]              test_set          0   Capitalize.
+[OK]              test_set          1   Add entries.
+The full test results are available in `_build/_tests`.
+Test Successful in 0.000s. 2 test run.
+$ ./simple.native test test_set 1
+Testing My first test.
+[SKIP]              test_set          0   Capitalize.
+[OK]                test_set          1   Add entries.
+The full test results are available in `_build/_tests`.
+Test Successful in 0.000s. 1 test run.
+```
+
 See the [examples](https://github.com/mirage/alcotest/tree/master/examples)
 folder for more examples.
 

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -314,10 +314,9 @@ let skip_label (path, _) = path, skip_fun
 let filter_test labels (test: path * 'a rrun) =
   let Path (n, i), _ = test in
   match labels with
-  | []    -> Some test
-  | [m]   -> if n=m then Some test else None
-  | [m;j] -> if n=m && int_of_string j = i then Some test else None
-  | _     -> failwith "filter_test"
+  | None, _ -> Some test
+  | Some m, None   -> if n=m then Some test else None
+  | Some m, Some j -> if n=m && j = i then Some test else None
 
 let map_test f l = List.map (fun (path, test) -> path, f path test) l
 
@@ -510,10 +509,15 @@ let default_cmd t args =
 
 let test_cmd t args =
   let doc = "Run a given test." in
-  let label =
-    let doc = "The list of labels identifying a subsets of the tests to run" in
-    Arg.(value & pos_all string [] & info [] ~doc ~docv:"LABEL")
+  let testname =
+    let doc = "The label (name) of the test identifying a subset of the tests to run" in
+    Arg.(value & pos 0 (some string) None & info [] ~doc ~docv:"NAME")
   in
+  let testcase =
+    let doc = "The test case number identifying a single test to run" in
+    Arg.(value & pos 1 (some int) None & info [] ~doc ~docv:"TESTCASE")
+  in
+  let label = Term.(pure (fun n t -> n, t) $ testname $ testcase) in
   Term.(pure run_subtest $ of_env t $ label $ set_color $ args),
   Term.info "test" ~doc
 

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -673,3 +673,5 @@ let line (oc:out_channel) ?color c =
   in
   let str: string = Fmt.(to_to_string @@ fun ppf -> line ppf ?color) c in
   Printf.fprintf oc "%s" str
+
+let () = at_exit (Format.pp_print_flush Format.err_formatter)

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -458,7 +458,7 @@ let run_registred_tests t () args =
 let run_subtest t labels () args =
   let is_empty = filter_tests ~subst:false labels t.tests = [] in
   if is_empty then (
-    Fmt.(pf stderr) "%a\n" red "Invalid request!";
+    Fmt.(pf stderr) "%a\n" red "Invalid request (no tests to run, filter skipped everything)!";
     exit 1
   ) else
     let tests = filter_tests ~subst:true labels t.tests in

--- a/src/alcotest.mli
+++ b/src/alcotest.mli
@@ -43,7 +43,8 @@ val test_case: string -> speed_level -> ('a -> unit) -> 'a test_case
     the function [f]. *)
 
 type 'a test = string * 'a test_case list
-(** A test is an US-ASCII encoded name and a list of test cases. *)
+(** A test is an US-ASCII encoded name and a list of test cases.
+ * The name can be used for filtering which tests to run on the CLI *)
 
 exception Test_error
 (** The exception return by {!run} in case of errors. *)


### PR DESCRIPTION
Filtering testcases was scarcely documented (had to read the source code to find out the expected format): add an example to the README, and make --help more explicit that up to 2 arguments can be used for filtering (the name of the test, and the test case index).

Also fix a bug with error messages getting lost on exit: OCaml doesn't flush Format.stderr on exit, just Format.stdout, so we have to flush it ourselves.

The improved output compared to the old one looks like this:
```diff
--- old
+++ new
@@ -1,15 +1,19 @@
 + ./simple test test_set invalidnumber
+simple: TESTCASE argument: invalid value `invalidnumber', expected an integer
+Usage: simple test [OPTION]... [NAME] [TESTCASE]
+Try `simple test --help' or `simple --help' for more information.
 Testing My first test.
 + echo '$?=' 1
 $?= 1

 + ./simple test nonexistent_name
+Invalid request (no tests to run, filter skipped everything)!
 Testing My first test.
 + echo '$?=' 1
 $?= 1

 + ./simple test test_set 1 trailingarguments
-simple: internal error, uncaught exception:
-        Failure("filter_test")
-
+simple: too many arguments, don't know what to do with `trailingarguments'
+Usage: simple test [OPTION]... [NAME] [TESTCASE]
+Try `simple test --help' or `simple --help' for more information.
 Testing My first test.
 + echo '$?=' 1
 $?= 1
```

No doubt the documentation could be improved further, this is just a start.