### PR TITLE
Creates a fresh log sub-directory on each run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
 script: bash -ex .travis-docker.sh
 services:
   - docker
@@ -7,17 +7,8 @@ sudo: false
 env:
  global:
    - PINS="alcotest:. alcotest-lwt:. alcotest-async:."
-   - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
  matrix:
-   - DISTRO=debian-stable OCAML_VERSION=4.04.1 PACKAGE="alcotest-lwt"
-   - DISTRO=debian-stable OCAML_VERSION=4.04.1 PACKAGE="alcotest-async"
-   - DISTRO=debian-testing OCAML_VERSION=4.02.3 PACKAGE="alcotest"
-   - DISTRO=debian-unstable OCAML_VERSION=4.03.0 PACKAGE="alcotest"
-   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.04.1 PACKAGE="alcotest-lwt"
-   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.04.1 PACKAGE="alcotest-async"
-   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.03.0 PACKAGE="alcotest"
-   - DISTRO=centos-6 OCAML_VERSION=4.02.3 PACKAGE="alcotest"
-   - DISTRO=centos-7 OCAML_VERSION=4.03.0 PACKAGE="alcotest"
-   - DISTRO=fedora-24 OCAML_VERSION=4.02.3 PACKAGE="alcotest-lwt"
-   - DISTRO=alpine OCAML_VERSION=4.03.0 PACKAGE="alcotest-lwt"
-   - DISTRO=alpine OCAML_VERSION=4.03.0 PACKAGE="alcotest-async"
+   - DISTRO=alpine          OCAML_VERSION=4.04 PACKAGE="alcotest-lwt"
+   - DISTRO=debian-stable   OCAML_VERSION=4.05 PACKAGE="alcotest-async"
+   - DISTRO=debian-testing  OCAML_VERSION=4.06 PACKAGE="alcotest"
+   - DISTRO=debian-unstable OCAML_VERSION=4.07 PACKAGE="alcotest"

--- a/alcotest.opam
+++ b/alcotest.opam
@@ -19,5 +19,6 @@ depends: [
   "astring"
   "result"
   "cmdliner"
+  "uuidm"
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -65,6 +65,7 @@ type 'a t = {
   json       : bool;
   verbose    : bool;
   test_dir   : string;
+  run_id     : Uuidm.t;
 
 }
 
@@ -81,9 +82,10 @@ let empty () =
   let show_errors = false in
   let json = false in
   let test_dir = Sys.getcwd () in
+  let run_id = Uuidm.nil in
   { name; errors; tests; paths; doc; speed;
     max_label; speed_level;
-    show_errors; json; verbose; test_dir }
+    show_errors; json; verbose; test_dir; run_id }
 
 let compare_speed_level s1 s2 =
   match s1, s2 with

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -65,7 +65,7 @@ type 'a t = {
   json       : bool;
   verbose    : bool;
   test_dir   : string;
-  run_id     : Uuidm.t;
+  run_id     : string;
 
 }
 
@@ -82,7 +82,7 @@ let empty () =
   let show_errors = false in
   let json = false in
   let test_dir = Sys.getcwd () in
-  let run_id = Uuidm.nil in
+  let run_id = Uuidm.to_string ~upper:true Uuidm.nil in
   { name; errors; tests; paths; doc; speed;
     max_label; speed_level;
     show_errors; json; verbose; test_dir; run_id }
@@ -156,7 +156,9 @@ let short_string_of_path (Path (n, i)) = Printf.sprintf "%s.%03d" n i
 let file_of_path path ext =
   Printf.sprintf "%s.%s" (short_string_of_path path) ext
 
-let output_file t path = Filename.concat t.test_dir (file_of_path path "output")
+let output_file t path =
+  let output_dir = Filename.concat t.test_dir t.run_id in
+  Filename.concat output_dir (file_of_path path "output")
 
 let mkdir_p path mode =
   let rec mk parent = function
@@ -385,7 +387,9 @@ let show_result t result =
     in
     let full_logs ppf =
       if t.verbose then Fmt.string ppf ""
-      else Fmt.pf ppf "The full test results are available in `%s`.\n" t.test_dir
+      else
+        Fmt.pf ppf "The full test results are available in `%s`.\n"
+          (Filename.concat t.test_dir t.run_id)
     in
     Fmt.pr "%t%t in %.3fs. %d test%s run.\n%!"
       full_logs test_results result.time result.success (s result.success)
@@ -528,9 +532,15 @@ let list_cmd t =
   Term.(pure list_tests $ of_env t $ set_color),
   Term.info "list" ~doc
 
+let random_state = Random.State.make_self_init ()
+
 let run_with_args ?(and_exit = true) ?argv name args (tl: 'a test list) =
+  let run_id =
+    Uuidm.v4_gen random_state ()
+    |> Uuidm.to_string ~upper:true in
   Fmt.(pf stdout) "Testing %a.\n" bold_s name;
-  let t = empty () in
+  Fmt.(pf stdout) "This run has ID `%s`." run_id;
+  let t = { (empty ()) with run_id=run_id} in
   let t = List.fold_left (fun t (name, tests) -> register t name tests) t tl in
   let choices = [
     list_cmd t;

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -156,9 +156,11 @@ let short_string_of_path (Path (n, i)) = Printf.sprintf "%s.%03d" n i
 let file_of_path path ext =
   Printf.sprintf "%s.%s" (short_string_of_path path) ext
 
+let output_dir t =
+  Filename.concat t.test_dir t.run_id
+
 let output_file t path =
-  let output_dir = Filename.concat t.test_dir t.run_id in
-  Filename.concat output_dir (file_of_path path "output")
+  Filename.concat (output_dir t) (file_of_path path "output")
 
 let mkdir_p path mode =
   let rec mk parent = function
@@ -173,7 +175,8 @@ let mkdir_p path mode =
   | ""::xs -> mk "/" xs | xs -> mk "." xs
 
 let prepare t =
-  if not (Sys.file_exists t.test_dir) then mkdir_p t.test_dir 0o755
+  let output_dir = output_dir t in
+  if not (Sys.file_exists output_dir) then mkdir_p output_dir 0o755
 
 let color c ppf fmt = Fmt.(styled c string) ppf fmt
 let red_s fmt = color `Red fmt
@@ -539,7 +542,7 @@ let run_with_args ?(and_exit = true) ?argv name args (tl: 'a test list) =
     Uuidm.v4_gen random_state ()
     |> Uuidm.to_string ~upper:true in
   Fmt.(pf stdout) "Testing %a.\n" bold_s name;
-  Fmt.(pf stdout) "This run has ID `%s`." run_id;
+  Fmt.(pf stdout) "This run has ID `%s`.\n" run_id;
   let t = { (empty ()) with run_id=run_id} in
   let t = List.fold_left (fun t (name, tests) -> register t name tests) t tl in
   let choices = [

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -175,8 +175,8 @@ let mkdir_p path mode =
   | ""::xs -> mk "/" xs | xs -> mk "." xs
 
 let prepare t =
-  let output_dir = output_dir t in
-  if not (Sys.file_exists output_dir) then mkdir_p output_dir 0o755
+  let test_dir = output_dir t in
+  if not (Sys.file_exists test_dir) then mkdir_p test_dir 0o755
 
 let color c ppf fmt = Fmt.(styled c string) ppf fmt
 let red_s fmt = color `Red fmt
@@ -392,7 +392,7 @@ let show_result t result =
       if t.verbose then Fmt.string ppf ""
       else
         Fmt.pf ppf "The full test results are available in `%s`.\n"
-          (Filename.concat t.test_dir t.run_id)
+          (output_dir t)
     in
     Fmt.pr "%t%t in %.3fs. %d test%s run.\n%!"
       full_logs test_results result.time result.success (s result.success)

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -481,8 +481,9 @@ let json =
   Arg.(value & flag & info ["json"] ~docv:"" ~doc)
 
 let test_dir =
+  let default_dir = Filename.concat (Sys.getcwd ()) "_build/_tests" in
   let doc = "Where to store the log files of the tests." in
-  Arg.(value & opt dir "_build/_tests"  & info ["o"] ~docv:"DIR" ~doc)
+  Arg.(value & opt dir default_dir & info ["o"] ~docv:"DIR" ~doc)
 
 let verbose =
   let env = Arg.env_var "ALCOTEST_VERBOSE" in

--- a/src/jbuild
+++ b/src/jbuild
@@ -5,4 +5,4 @@
   (public_name alcotest)
   (wrapped false)
   (libraries
-   (fmt astring result cmdliner fmt.cli fmt.tty))))
+   (fmt astring result cmdliner fmt.cli fmt.tty uuidm))))


### PR DESCRIPTION
#125 
--
This proposed change takes a dependency on `uuidm` to generate UUIDs. It extends the `alcotest` global state to hold a globally unique run ID. This ID is newly generated on each call into `run_with_args` and is displayed out to the user before running any tests. The output logs from the tests are then placed in this sub directory which itself is under the `-o` directory (or under the default test directory if this is not specified).

To test this change I pinned my local clone with the changes, built the test executable of another project and repeatedly manually invoked it. The output logs were subsequently generated in separate sub-directories corresponding to the ID of the run, as expected.

#135 
--
This was caused by `dune` altering the current working directory before running tests. It would not explicitly pass in a `-o` parameter and so the default one was taken which was a relative path. The result of this was that a relative path was printed to the user and while this was correct it wasn't obvious that it was from a different current working directory. My fix made the default parameter an absolute path under the current working directory with the same relative path (functionally this is a no-op change). This meant when printed to the user it is now correct.