### PR TITLE
fix output path for windows/cygwin

### DIFF
--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -163,16 +163,20 @@ let output_file t path =
   Filename.concat (output_dir t) (file_of_path path "output")
 
 let mkdir_p path mode =
+  let sep = Filename.dir_sep in
   let rec mk parent = function
   | [] -> ()
   | name::names ->
-      let path = parent ^ "/" ^ name in
+      let path = parent ^ sep ^ name in
       begin try if not (Sys.is_directory path) then
         Fmt.strf "mkdir: %s: is a file" path |> failwith
       with Sys_error _ -> Unix.mkdir path mode end;
       mk path names in
-  match String.cuts ~empty:true ~sep:"/" path with
-  | ""::xs -> mk "/" xs | xs -> mk "." xs
+  match String.cuts ~empty:true ~sep:sep path with
+  | ""::xs -> mk sep xs
+  (* check for Windows drive letter *)
+  | dl::xs when Str.string_match (Str.regexp "[A-Z]:") dl 0 -> mk dl xs
+  | xs -> mk "." xs
 
 let prepare t =
   let test_dir = output_dir t in
@@ -481,7 +485,8 @@ let json =
   Arg.(value & flag & info ["json"] ~docv:"" ~doc)
 
 let test_dir =
-  let default_dir = Filename.concat (Sys.getcwd ()) "_build/_tests" in
+  let fname_concat l = List.fold_left Filename.concat "" l in
+  let default_dir = fname_concat [Sys.getcwd (); "_build"; "_tests"] in
   let doc = "Where to store the log files of the tests." in
   Arg.(value & opt dir default_dir & info ["o"] ~docv:"DIR" ~doc)
 

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -163,6 +163,11 @@ let output_file t path =
   Filename.concat (output_dir t) (file_of_path path "output")
 
 let mkdir_p path mode =
+  let is_win_drive_letter x =
+    String.length x = 2
+    && x.[1] = ':'
+    && Char.Ascii.is_letter x.[0]
+  in
   let sep = Filename.dir_sep in
   let rec mk parent = function
   | [] -> ()
@@ -175,7 +180,7 @@ let mkdir_p path mode =
   match String.cuts ~empty:true ~sep:sep path with
   | ""::xs -> mk sep xs
   (* check for Windows drive letter *)
-  | dl::xs when Str.string_match (Str.regexp "[A-Z]:") dl 0 -> mk dl xs
+  | dl::xs when is_win_drive_letter dl -> mk dl xs
   | xs -> mk "." xs
 
 let prepare t =

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,3 @@
 (library
  (public_name alcotest)
- (libraries   fmt astring result cmdliner fmt.cli fmt.tty uuidm))
+ (libraries   fmt astring result cmdliner fmt.cli fmt.tty uuidm str))

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,3 @@
 (library
  (public_name alcotest)
- (libraries   fmt astring result cmdliner fmt.cli fmt.tty uuidm str))
+ (libraries   fmt astring result cmdliner fmt.cli fmt.tty uuidm))


### PR DESCRIPTION
This is a fix for #140:

- hard-coded path separator "/" has been replaced by `Filename.dir_sep`
- `mkdir_p` now can deal with Windows absolute paths, containing drive letters, e.g., C:\

Tested on Windows 10 cygwin/mingw toolchain & Windows 10 WSL aka Bash for Windows (Ubuntu 18.04)

Default path shown by `test_runner --help` still looks broken, but this is only a cosmetic issue (probably needs more escaping for "\\")