### PR TITLE
Windows fix2

### DIFF
--- a/alcotest.opam
+++ b/alcotest.opam
@@ -20,5 +20,6 @@ depends: [
   "result"
   "cmdliner"
   "uuidm"
+  "fpath"
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -163,16 +163,20 @@ let output_file t path =
   Filename.concat (output_dir t) (file_of_path path "output")
 
 let mkdir_p path mode =
+  let sep = Filename.dir_sep in
   let rec mk parent = function
   | [] -> ()
   | name::names ->
-      let path = parent ^ "/" ^ name in
+      let path = parent ^ sep ^ name in
       begin try if not (Sys.is_directory path) then
         Fmt.strf "mkdir: %s: is a file" path |> failwith
       with Sys_error _ -> Unix.mkdir path mode end;
       mk path names in
-  match String.cuts ~empty:true ~sep:"/" path with
-  | ""::xs -> mk "/" xs | xs -> mk "." xs
+  match String.cuts ~empty:true ~sep:sep path with
+  | ""::xs -> mk sep xs
+  (* check for Windows drive letter *)
+  | dl::xs when Str.string_match (Str.regexp "[A-Z]:") dl 0 -> mk dl xs
+  | xs -> mk "." xs
 
 let prepare t =
   let test_dir = output_dir t in
@@ -481,7 +485,8 @@ let json =
   Arg.(value & flag & info ["json"] ~docv:"" ~doc)
 
 let test_dir =
-  let default_dir = Filename.concat (Sys.getcwd ()) "_build/_tests" in
+  let fname_concat l = List.fold_left Filename.concat "" l in
+  let default_dir = fname_concat [Sys.getcwd (); "_build"; "_tests"] in
   let doc = "Where to store the log files of the tests." in
   Arg.(value & opt dir default_dir & info ["o"] ~docv:"DIR" ~doc)
 

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -172,11 +172,10 @@ let mkdir_p path mode =
         Fmt.strf "mkdir: %s: is a file" path |> failwith
       with Sys_error _ -> Unix.mkdir path mode end;
       mk path names in
-  match String.cuts ~empty:true ~sep:sep path with
-  | ""::xs -> mk sep xs
-  (* check for Windows drive letter *)
-  | dl::xs when Str.string_match (Str.regexp "[A-Z]:") dl 0 -> mk dl xs
-  | xs -> mk "." xs
+  let fp = Fpath.v path in
+  match Fpath.split_volume fp with
+  | "",  p -> if Fpath.is_abs p then mk sep (Fpath.segs p) else mk "." (Fpath.segs p)
+  | v, p   -> mk v (Fpath.segs p)
 
 let prepare t =
   let test_dir = output_dir t in

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,3 @@
 (library
  (public_name alcotest)
- (libraries   fmt astring result cmdliner fmt.cli fmt.tty uuidm str))
+ (libraries   fmt astring result cmdliner fmt.cli fmt.tty uuidm fpath))

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,3 @@
 (library
  (public_name alcotest)
- (libraries   fmt astring result cmdliner fmt.cli fmt.tty uuidm))
+ (libraries   fmt astring result cmdliner fmt.cli fmt.tty uuidm str))


### PR DESCRIPTION
Another fix for path handling on Windows, using [fpath package](https://opam.ocaml.org/packages/fpath/) instead of Str module. #141 