### PR TITLE
release 0.8.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ env:
    - DISTRO=alpine          OCAML_VERSION=4.04 PACKAGE="alcotest-lwt"
    - DISTRO=debian-stable   OCAML_VERSION=4.05 PACKAGE="alcotest-async"
    - DISTRO=debian-testing  OCAML_VERSION=4.06 PACKAGE="alcotest"
-   - DISTRO=debian-unstable OCAML_VERSION=4.07 PACKAGE="alcotest"
+   - DISTRO=fedora          OCAML_VERSION=4.07 PACKAGE="alcotest"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+### 0.8.5 (2018-12-11)
+- Port build to Dune from jbuilder (#139 @samoht)
+- Fix output path on Windows/Cygwin (#141 @kkirstein)
+- Switch opam metadata to 2.0 format (#144 @samoht)
+- Add nice screenshots to the README (#143 @rizo)
+- Fix ocamldoc headings to work with odoc (#145 @avsm)
+- Do not test on Debian-unstable, add Fedora (#145 @avsm)
+
 ### 0.8.4 (2018-10-17)
 
 - Improve documentation for speed and tests (#129, @raphael-proust)

--- a/src/alcotest.mli
+++ b/src/alcotest.mli
@@ -71,7 +71,7 @@ val run_with_args: ?and_exit:bool -> ?argv:string array ->
     evaluation of the [Cdmliner] term [a]: this is useful to configure
     the test behaviors using the CLI. *)
 
-(** {1 Assert functions} *)
+(** {2 Assert functions} *)
 
 (** [TESTABLE] provides an abstract description for testable
     values. *)
@@ -170,7 +170,7 @@ val neg: 'a testable -> 'a testable
 val check_raises: string -> exn -> (unit -> unit) -> unit
 (** Check that an exception is raised. *)
 
-(** {1 Deprecated} *)
+(** {2 Deprecated} *)
 
 val line: out_channel -> ?color:[`Blue|`Yellow] -> char -> unit
 (** @deprecated


### PR DESCRIPTION
Minor changes and update README:
- fix ocamldoc headings with latest odoc
- do not test on debian-unstable (moving target) and use
  fedora there instead