### PR TITLE
Add silent option

### DIFF
--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -259,10 +259,11 @@ let print_event t = function
     print_info t p;
   | `Result (_, r) when t.silent -> begin
       let c = match r with
-        | `Ok -> "."
-        | `Error _ | `Exn _ -> "E"
-        | `Skip -> "S"
-        | `Todo _ -> "T"
+        | `Exn _   -> "F"
+        | `Error _ -> "E"
+        | `Skip    -> "S"
+        | `Todo _  -> "T"
+        | `Ok      -> "."
       in
       print t (fun ppf -> Fmt.string ppf c)
     end

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -41,8 +41,6 @@ let test_case n s f = (n, s, f)
 
 type 'a test = string * 'a test_case list
 
-let quiet = ref false
-
 (* global state *)
 type 'a t = {
 
@@ -463,7 +461,6 @@ exception Test_error
 let apply fn t test_dir verbose show_errors quick json =
   let show_errors = show_errors in
   let speed_level = if quick then `Quick else `Slow in
-  if json then quiet := false;
   let t = { t with verbose; test_dir; json; show_errors; speed_level } in
   fn t
 
@@ -658,12 +655,9 @@ let reject (type a) =
   (module M: TESTABLE with type t = M.t)
 
 let show_line msg =
-  if !quiet then ()
-  else (
-    line Fmt.stderr ~color:`Yellow '-';
-    Printf.eprintf "ASSERT %s\n" msg;
-    line Fmt.stderr ~color:`Yellow '-';
-  )
+  line Fmt.stderr ~color:`Yellow '-';
+  Printf.eprintf "ASSERT %s\n" msg;
+  line Fmt.stderr ~color:`Yellow '-'
 
 let check_err fmt = Format.ksprintf (fun err -> raise (Check_error err)) fmt
 

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -238,7 +238,6 @@ let error t path fmt =
 
 let reset t = print t (fun ppf -> Fmt.string ppf "\r")
 let newline t = print t (fun ppf -> Fmt.string ppf "\n")
-let dot t = print t (fun ppf -> Fmt.string ppf ".")
 
 let print_result t p = function
   | `Ok            ->
@@ -258,10 +257,16 @@ let print_event t = function
   | `Start p       ->
     print t (fun ppf -> left left_c yellow_s ppf " ...");
     print_info t p;
-  | `Result (_, (`Ok | `Skip)) when t.silent ->
-    dot t
+  | `Result (_, r) when t.silent -> begin
+      let c = match r with
+        | `Ok -> "."
+        | `Error _ | `Exn _ -> "E"
+        | `Skip -> "S"
+        | `Todo _ -> "T"
+      in
+      print t (fun ppf -> Fmt.string ppf c)
+    end
   | `Result (p, r) ->
-    if t.silent then newline t;
     reset t;
     print_result t p r;
     newline t


### PR DESCRIPTION
This PR adds option `--silent` which will suppress output for all successful tests.
It contains two commits - one which removes an unused global mutable variable (quiet), and one to add option `--silent`
This addresses #146. 

I did not want this PR to be too intrusive, so there are some `if t.silent then ...` scattered around the code.  Also I would have preferred to not have the first two lines printed (see examples below), but these are printed before any command line arguments are parsed, and I did not want to change the current flow.

Example when all tests are successful:
```
$ dune exec drivers/yaml/test/unittest.exe -- --silent
Testing yaml.
This run has ID `E09E988F-081E-4894-A7CB-E2D3FCFB60A5`.
...............................................................
```

Example with one failing test:
```
$ dune exec drivers/yaml/test/unittest.exe -- --silent
Testing yaml.      
This run has ID `835BF394-F1E5-476D-8A51-14C558AC4D4D`.
................
[ERROR]             Maybe fail                      0   Fail test case.
.............................................
-- Maybe fail.000 [Fail test case.] Failed --
in /home/afu/git/ppx_protocol_conv/_build/_tests/835BF394-F1E5-476D-8A51-14C558AC4D4D/Maybe fail.000.output:
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
ASSERT Blah
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
[failure] Error Blah: expecting
0, got
1.
Raised at file "stdlib.ml", line 33, characters 17-33
Called from file "src/alcotest.ml", line 290, characters 8-14


The full test results are available in `/home/afu/git/ppx_protocol_conv/_build/_tests/835BF394-F1E5-476D-8A51-14C558AC4D4D`.
1 error! in 0.005s. 62 tests run.
```
