### PR TITLE
alcotest: fix EEXIST on mkdir

### DIFF
--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -173,9 +173,14 @@ let mkdir_p path mode =
   | [] -> ()
   | name::names ->
       let path = parent ^ sep ^ name in
-      begin try if not (Sys.is_directory path) then
-        Fmt.strf "mkdir: %s: is a file" path |> failwith
-      with Sys_error _ -> Unix.mkdir path mode end;
+      begin
+        try Unix.mkdir path mode
+        with Unix.Unix_error(Unix.EEXIST, _, _) ->
+          if Sys.is_directory path then
+            () (* the directory exists *)
+          else
+            Fmt.strf "mkdir: %s: is a file" path |> failwith
+      end;
       mk path names in
   match String.cuts ~empty:true ~sep:sep path with
   | ""::xs -> mk sep xs


### PR DESCRIPTION
Our CI is particularly "good" at finding race conditions in unit tests today for some reason, latest victim is alcotest:
```
unittest.exe: internal error, uncaught exception:                                                                                                                  
              Unix.Unix_error(Unix.EEXIST, "mkdir", "//builddir/build/BUILD/...../_build/default/test/fake/_build")
```

This is a TOCTOU race condition between checking that the directory does not exist and creating it. Avoid it by ignoring EEXIST on mkdir, if we get EEXIST then we lost the race condition and someone else has already created the directory, but that is fine: all we wanted is to ensure the directory exists in the first place.