### PR TITLE
Test output dirs: Create symlinks for each test suite + "latest"

### DIFF
--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -189,7 +189,19 @@ let mkdir_p path mode =
 
 let prepare t =
   let test_dir = output_dir t in
-  if not (Sys.file_exists test_dir) then mkdir_p test_dir 0o770
+  if not (Sys.file_exists test_dir) then begin
+    mkdir_p test_dir 0o770 ;
+    if Sys.unix || Sys.cygwin then begin
+      let this_exe = Filename.concat t.test_dir t.name
+      and latest = Filename.concat t.test_dir "latest" in
+      if Sys.file_exists this_exe then Sys.remove this_exe ;
+      if Sys.file_exists latest then Sys.remove latest ;
+      Unix.symlink ~to_dir:true test_dir this_exe ;
+      Unix.symlink ~to_dir:true test_dir latest ;
+    end
+  end else if not (Sys.is_directory test_dir) then
+    failwith (Fmt.strf "exists but is not a directory: %S" test_dir)
+
 
 let color c ppf fmt = Fmt.(styled c string) ppf fmt
 let red_s fmt = color `Red fmt

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -189,7 +189,7 @@ let mkdir_p path mode =
 
 let prepare t =
   let test_dir = output_dir t in
-  if not (Sys.file_exists test_dir) then mkdir_p test_dir 0o755
+  if not (Sys.file_exists test_dir) then mkdir_p test_dir 0o770
 
 let color c ppf fmt = Fmt.(styled c string) ppf fmt
 let red_s fmt = color `Red fmt
@@ -329,7 +329,7 @@ let with_redirect file fn =
   let fd_stderr = Unix.descr_of_out_channel stderr in
   let fd_old_stdout = Unix.dup fd_stdout in
   let fd_old_stderr = Unix.dup fd_stderr in
-  let fd_file = Unix.(openfile file [O_WRONLY; O_TRUNC; O_CREAT] 0o666) in
+  let fd_file = Unix.(openfile file [O_WRONLY; O_TRUNC; O_CREAT] 0o660) in
   Unix.dup2 fd_file fd_stdout;
   Unix.dup2 fd_file fd_stderr;
   Unix.close fd_file;


### PR DESCRIPTION
Test output directories: Create symlinks for each test suite, and a "latest" symlink.

- The "latest" symlink points to the last test executed. This is useful to quickly navigate to whichever directory contains failing tests.

- Additionally a symlink named after t.name (in turn named after argv[0] of the test executable) is created. This is useful when there are multiple test executables being compiled as part of a build chain.

- Also try to avoid creating world-writable directories and files by setting umask and changing explicit permissions to og-rwx. This is best-effort, but since OCaml doesn't provide adequate bindings to the Unix system calls it is hard to perform operations like deleting files and creating directories recursively without introducing TOCTOU race conditions that can be exploited by less-privileged processes running on the machine.

- After executing my test suite three times, my test dir now looks like:
```shell
$ ls /home/user/ocaml/xi-rope/_build/_tests/ -la
total 28
drwx------ 5 user user 4096 Jul 14 05:48 .
drwxr-xr-x 7 user user 4096 Jul 14 05:47 ..
drwx------ 2 user user 4096 Jul 14 05:48 A3DC6B25-317A-4DA8-8BF8-FA2FE0FD5A3E
drwx------ 2 user user 4096 Jul 14 05:48 CDF189EE-35C2-43E8-A6A0-D62F86BED1B3
drwx------ 2 user user 4096 Jul 14 05:48 F4100A63-F959-47E5-889A-311F29BB2594
lrwxrwxrwx 1 user user   75 Jul 14 05:48 latest -> /home/user/ocaml/xi-rope/_build/_tests/F4100A63-F959-47E5-889A-311F29BB2594
lrwxrwxrwx 1 user user   75 Jul 14 05:48 tests.native -> /home/user/ocaml/xi-rope/_build/_tests/F4100A63-F959-47E5-889A-311F29BB2594
```

fixes #147