### PR TITLE
dune build @fmt: upgrade to ocamlformat.0.10

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,2 @@
+version = 0.10
+profile = conventional

--- a/async/alcotest_async.ml
+++ b/async/alcotest_async.ml
@@ -6,11 +6,10 @@ let run timeout name fn args =
   Thread_safe.block_on_async_exn (fun () ->
       Clock.with_timeout timeout (fn args) >>| function
       | `Result x -> x
-      | `Timeout -> Alcotest.fail (
-          Printf.sprintf "%s timed out after %s"
-            name (Time.Span.to_string_hum timeout)
-        )
-    )
+      | `Timeout ->
+          Alcotest.fail
+            (Printf.sprintf "%s timed out after %s" name
+               (Time.Span.to_string_hum timeout)))
 
-let test_case ?(timeout=sec 2.) name s f =
+let test_case ?(timeout = sec 2.) name s f =
   Alcotest.test_case name s (run timeout name f)

--- a/async/alcotest_async.mli
+++ b/async/alcotest_async.mli
@@ -17,9 +17,9 @@
 (** [Alcotest_async] allows to defines tests which returns an Async deferred.
     {!run} will schedule these deferreds and return their results. *)
 
-val test_case
-  : ?timeout:Core_kernel.Time.Span.t
-  -> string
-  -> Alcotest.speed_level
-  -> ('a -> unit Async_kernel.Deferred.t)
-  -> 'a Alcotest.test_case
+val test_case :
+  ?timeout:Core_kernel.Time.Span.t ->
+  string ->
+  Alcotest.speed_level ->
+  ('a -> unit Async_kernel.Deferred.t) ->
+  'a Alcotest.test_case

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
 (lang dune 1.1)
 (name alcotest)
+(using fmt 1.0)

--- a/examples/bad/bad.ml
+++ b/examples/bad/bad.ml
@@ -31,34 +31,30 @@ For more information, please refer to <http://unlicense.org/>
 (* A module with functions to test *)
 module To_test = struct
   let capit letter = Astring.String.Ascii.uppercase letter
+
   let plus int_list = List.map (fun a -> a + a) int_list
 end
 
 (* The tests *)
-let capit () =
-  Alcotest.(check string) "strings" "A" (To_test.capit "b")
+let capit () = Alcotest.(check string) "strings" "A" (To_test.capit "b")
 
 let plus () =
-  Alcotest.(check (list int)) "int lists" [1] (To_test.plus [1;1;2;3])
+  Alcotest.(check (list int)) "int lists" [ 1 ] (To_test.plus [ 1; 1; 2; 3 ])
 
-let test_one = [
-  "Capitalize" , `Quick, capit;
-  "Add entries", `Slow , plus ;
-]
+let test_one = [ ("Capitalize", `Quick, capit); ("Add entries", `Slow, plus) ]
 
-let test_two = [
-  "ok"         , `Quick, (fun () -> ());
-  "Capitalize" , `Quick, capit;
-  "ok"         , `Quick, (fun () -> ());
-]
+let test_two =
+  [ ("ok", `Quick, fun () -> ());
+    ("Capitalize", `Quick, capit);
+    ("ok", `Quick, fun () -> ())
+  ]
 
 (* Run it *)
 let one () =
-  try Alcotest.run ~and_exit:false "My first test" ["Ωèone", test_one]
+  try Alcotest.run ~and_exit:false "My first test" [ ("Ωèone", test_one) ]
   with Alcotest.Test_error -> Printf.printf "Continue!!\n%!"
 
-let two () =
-  Alcotest.run ~and_exit:true "Hoho" ["two", test_two]
+let two () = Alcotest.run ~and_exit:true "Hoho" [ ("two", test_two) ]
 
 let () =
   one ();

--- a/examples/floats.ml
+++ b/examples/floats.ml
@@ -46,17 +46,10 @@ let others () =
   Alcotest.(check @@ neg @@ float e) "1 is not 0" 1. 0.;
   Alcotest.(check @@ float e) ".3 is .3" (0.1 +. 0.2) 0.3
 
-let edge_set = [
-  "NaN", `Quick, nan     ;
-  "∞",   `Quick, infinity;
-]
+let edge_set = [ ("NaN", `Quick, nan); ("∞", `Quick, infinity) ]
 
-let others_set = [
-  "others", `Quick, others;
-]
+let others_set = [ ("others", `Quick, others) ]
 
 let () =
-  Alcotest.run "Float tests" [
-    "Edge cases",   edge_set  ;
-    "Other floats", others_set;
-  ]
+  Alcotest.run "Float tests"
+    [ ("Edge cases", edge_set); ("Other floats", others_set) ]

--- a/examples/simple.ml
+++ b/examples/simple.ml
@@ -31,24 +31,21 @@ For more information, please refer to <http://unlicense.org/>
 (* A module with functions to test *)
 module To_test = struct
   let capit letter = Astring.Char.Ascii.uppercase letter
+
   let plus int_list = List.fold_left (fun a b -> a + b) 0 int_list
 end
 
 (* The tests *)
-let capit () =
-  Alcotest.(check char) "Check A" 'A' (To_test.capit 'a')
+let capit () = Alcotest.(check char) "Check A" 'A' (To_test.capit 'a')
 
 let plus () =
-  Alcotest.(check int) "Sum equals to 7" 7 (To_test.plus [1;1;2;3])
+  Alcotest.(check int) "Sum equals to 7" 7 (To_test.plus [ 1; 1; 2; 3 ])
 
-let test_set = [
-  "\xF0\x9F\x90\xAB  Capitalize", `Quick, capit;
-  "Add entries"                 , `Slow , plus ;
-]
+let test_set =
+  [ ("\xF0\x9F\x90\xAB  Capitalize", `Quick, capit);
+    ("Add entries", `Slow, plus)
+  ]
 
 (* Run it *)
 let () =
-  Alcotest.run "My first test" [
-    "test_1", test_set;
-    "test_2", test_set;
-  ]
+  Alcotest.run "My first test" [ ("test_1", test_set); ("test_2", test_set) ]

--- a/lwt/alcotest_lwt.ml
+++ b/lwt/alcotest_lwt.ml
@@ -18,12 +18,10 @@ let run fn args =
   let async_ex, async_waker = Lwt.wait () in
   let handle_exn ex =
     Logs.debug (fun f -> f "Uncaught async exception: %a" Fmt.exn ex);
-    if Lwt.state async_ex = Lwt.Sleep then
-      Lwt.wakeup_exn async_waker ex
+    if Lwt.state async_ex = Lwt.Sleep then Lwt.wakeup_exn async_waker ex
   in
   Lwt.async_exception_hook := handle_exn;
-  Lwt_main.run @@
-  Lwt_switch.with_switch (fun sw -> Lwt.pick [fn sw args; async_ex])
+  Lwt_main.run
+  @@ Lwt_switch.with_switch (fun sw -> Lwt.pick [ fn sw args; async_ex ])
 
-let test_case n s f =
-  Alcotest.test_case n s (run f)
+let test_case n s f = Alcotest.test_case n s (run f)

--- a/lwt/alcotest_lwt.mli
+++ b/lwt/alcotest_lwt.mli
@@ -18,5 +18,8 @@
     promise. {!run} will run these promises and will catch asynchrous
     exceptions. *)
 
-val test_case: string -> Alcotest.speed_level ->
-  (Lwt_switch.t -> 'a -> unit Lwt.t) -> 'a Alcotest.test_case
+val test_case :
+  string ->
+  Alcotest.speed_level ->
+  (Lwt_switch.t -> 'a -> unit Lwt.t) ->
+  'a Alcotest.test_case

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -16,27 +16,27 @@
 
 open Astring
 
-module IntSet = Set.Make ( struct
-    let compare = Pervasives.compare
-    type t = int
-  end )
+module IntSet = Set.Make (struct
+  let compare = Pervasives.compare
+
+  type t = int
+end)
 
 exception Check_error of string
 
 (* Types *)
-type speed_level = [`Quick | `Slow]
+type speed_level = [ `Quick | `Slow ]
 
 type 'a run = 'a -> unit
 
 type path = Path of (string * int)
 
-type run_result = [
-  | `Ok
+type run_result =
+  [ `Ok
   | `Exn of path * string * string
   | `Error of path * string
   | `Skip
-  | `Todo of string
-]
+  | `Todo of string ]
 
 type 'a rrun = 'a -> run_result
 
@@ -48,28 +48,24 @@ type 'a test = string * 'a test_case list
 
 (* global state *)
 type 'a t = {
-
   (* library values. *)
   name : string;
-  tests: (path * 'a rrun) list;
-
+  tests : (path * 'a rrun) list;
   (* caches computed from the library values. *)
-  paths: path list;
-  doc  : path -> string option;
-  speed: path -> speed_level option;
-
+  paths : path list;
+  doc : path -> string option;
+  speed : path -> speed_level option;
   (* runtime state. *)
-  mutable errors: string list;
-
+  mutable errors : string list;
   (* runtime options. *)
-  max_label: int;
-  speed_level: speed_level;
-  show_errors: bool;
-  json       : bool;
-  verbose    : bool;
-  compact    : bool;
-  test_dir   : string;
-  run_id     : string;
+  max_label : int;
+  speed_level : speed_level;
+  show_errors : bool;
+  json : bool;
+  verbose : bool;
+  compact : bool;
+  test_dir : string;
+  run_id : string;
 }
 
 let empty () =
@@ -87,47 +83,60 @@ let empty () =
   let json = false in
   let test_dir = Sys.getcwd () in
   let run_id = Uuidm.to_string ~upper:true Uuidm.nil in
-  { name; errors; tests; paths; doc; speed;
-    max_label; speed_level;
-    show_errors; json; verbose; compact; test_dir; run_id }
+  {
+    name;
+    errors;
+    tests;
+    paths;
+    doc;
+    speed;
+    max_label;
+    speed_level;
+    show_errors;
+    json;
+    verbose;
+    compact;
+    test_dir;
+    run_id;
+  }
 
 let compare_speed_level s1 s2 =
-  match s1, s2 with
-  | `Quick, `Quick
-  | `Slow , `Slow  -> 0
-  | `Quick, _      -> 1
-  | _     , `Quick -> -1
+  match (s1, s2) with
+  | `Quick, `Quick | `Slow, `Slow -> 0
+  | `Quick, _ -> 1
+  | _, `Quick -> -1
 
 let with_process_in cmd f =
   let ic = Unix.open_process_in cmd in
   try
     let r = f ic in
-    ignore (Unix.close_process_in ic) ; r
+    ignore (Unix.close_process_in ic);
+    r
   with exn ->
-    ignore (Unix.close_process_in ic) ; raise exn
+    ignore (Unix.close_process_in ic);
+    raise exn
 
 let terminal_columns =
   try
     (* terminfo *)
     with_process_in "tput cols" (fun ic -> int_of_string (input_line ic))
-  with _ -> try
+  with _ -> (
+    try
       (* GNU stty *)
       with_process_in "stty size" (fun ic ->
           match String.cuts (input_line ic) ~sep:" " with
-          | [_ ; v] -> int_of_string v
+          | [ _; v ] -> int_of_string v
           | _ -> failwith "stty")
-    with _ -> try
-        (* shell envvar *)
-        int_of_string (Sys.getenv "COLUMNS")
-      with _ ->
-        (* default *)
-        80
+    with _ -> (
+      try (* shell envvar *)
+          int_of_string (Sys.getenv "COLUMNS") with _ -> (* default *)
+                                                         80 ) )
 
 let line ppf ?color c =
   let line = String.v ~len:terminal_columns (fun _ -> c) in
   match color with
-  | Some c -> Fmt.pf ppf "%a\n%!" Fmt.(styled c string)  line
-  | None   -> Fmt.pf ppf "%s\n%!"line
+  | Some c -> Fmt.pf ppf "%a\n%!" Fmt.(styled c string) line
+  | None -> Fmt.pf ppf "%s\n%!" line
 
 let left nb pp ppf a =
   let s = Fmt.to_to_string pp a in
@@ -135,8 +144,7 @@ let left nb pp ppf a =
   if nb <= 0 then pp ppf a
   else (
     pp ppf a;
-    Fmt.string ppf (String.v ~len:nb (fun _ -> ' '))
-  )
+    Fmt.string ppf (String.v ~len:nb (fun _ -> ' ')) )
 
 let print t k = if not t.json then k Fmt.stdout
 
@@ -145,13 +153,11 @@ let string_of_channel ic =
   let s = Bytes.create n in
   let b = Buffer.create 1024 in
   let rec iter ic b s =
-    let nread =
-      try input ic s 0 n
-      with End_of_file -> 0 in
+    let nread = try input ic s 0 n with End_of_file -> 0 in
     if nread > 0 then (
       Buffer.add_substring b (Bytes.unsafe_to_string s) 0 nread;
-      iter ic b s
-    ) in
+      iter ic b s )
+  in
   iter ic b s;
   Buffer.contents b
 
@@ -160,88 +166,80 @@ let short_string_of_path (Path (n, i)) = Printf.sprintf "%s.%03d" n i
 let file_of_path path ext =
   Printf.sprintf "%s.%s" (short_string_of_path path) ext
 
-let output_dir t =
-  Filename.concat t.test_dir t.run_id
+let output_dir t = Filename.concat t.test_dir t.run_id
 
 let output_file t path =
   Filename.concat (output_dir t) (file_of_path path "output")
 
 let mkdir_p path mode =
   let is_win_drive_letter x =
-    String.length x = 2
-    && x.[1] = ':'
-    && Char.Ascii.is_letter x.[0]
+    String.length x = 2 && x.[1] = ':' && Char.Ascii.is_letter x.[0]
   in
   let sep = Filename.dir_sep in
   let rec mk parent = function
-  | [] -> ()
-  | name::names ->
-      let path = parent ^ sep ^ name in
-      begin
-        try Unix.mkdir path mode
-        with Unix.Unix_error(Unix.EEXIST, _, _) ->
-          if Sys.is_directory path then
-            () (* the directory exists *)
-          else
-            Fmt.strf "mkdir: %s: is a file" path |> failwith
-      end;
-      mk path names in
-  match String.cuts ~empty:true ~sep:sep path with
-  | ""::xs -> mk sep xs
+    | [] -> ()
+    | name :: names ->
+        let path = parent ^ sep ^ name in
+        ( try Unix.mkdir path mode
+          with Unix.Unix_error (Unix.EEXIST, _, _) ->
+            if Sys.is_directory path then () (* the directory exists *)
+            else Fmt.strf "mkdir: %s: is a file" path |> failwith );
+        mk path names
+  in
+  match String.cuts ~empty:true ~sep path with
+  | "" :: xs -> mk sep xs
   (* check for Windows drive letter *)
-  | dl::xs when is_win_drive_letter dl -> mk dl xs
+  | dl :: xs when is_win_drive_letter dl -> mk dl xs
   | xs -> mk "." xs
 
 let prepare t =
   let test_dir = output_dir t in
-  if not (Sys.file_exists test_dir) then begin
-    mkdir_p test_dir 0o770 ;
-    if Sys.unix || Sys.cygwin then begin
+  if not (Sys.file_exists test_dir) then (
+    mkdir_p test_dir 0o770;
+    if Sys.unix || Sys.cygwin then (
       let this_exe = Filename.concat t.test_dir t.name
       and latest = Filename.concat t.test_dir "latest" in
-      if Sys.file_exists this_exe then Sys.remove this_exe ;
-      if Sys.file_exists latest then Sys.remove latest ;
-      Unix.symlink ~to_dir:true test_dir this_exe ;
-      Unix.symlink ~to_dir:true test_dir latest ;
-    end
-  end else if not (Sys.is_directory test_dir) then
+      if Sys.file_exists this_exe then Sys.remove this_exe;
+      if Sys.file_exists latest then Sys.remove latest;
+      Unix.symlink ~to_dir:true test_dir this_exe;
+      Unix.symlink ~to_dir:true test_dir latest ) )
+  else if not (Sys.is_directory test_dir) then
     failwith (Fmt.strf "exists but is not a directory: %S" test_dir)
 
-
 let color c ppf fmt = Fmt.(styled c string) ppf fmt
+
 let red_s fmt = color `Red fmt
+
 let red ppf fmt = Fmt.kstrf (fun str -> red_s ppf str) fmt
+
 let green_s fmt = color `Green fmt
+
 let yellow_s fmt = color `Yellow fmt
+
 let bold_s fmt = color `Bold fmt
+
 let cyan_s fmt = color `Cyan fmt
 
 let pp_path t ppf (Path (n, i)) =
-  Fmt.pf ppf "%a%3d" (left (t.max_label+8) cyan_s) n i
+  Fmt.pf ppf "%a%3d" (left (t.max_label + 8) cyan_s) n i
 
-let doc_of_path t path =
-  match t.doc path with
-  | None  -> ""
-  | Some d -> d
+let doc_of_path t path = match t.doc path with None -> "" | Some d -> d
 
 let speed_of_path t path =
-  match t.speed path with
-  | None   -> `Slow
-  | Some s -> s
+  match t.speed path with None -> `Slow | Some s -> s
 
 let print_info t p =
-  print t (fun ppf ->
-      Fmt.pf ppf "%a   %s" (pp_path t) p (doc_of_path t p)
-    )
+  print t (fun ppf -> Fmt.pf ppf "%a   %s" (pp_path t) p (doc_of_path t p))
 
 let left_c = 20
 
 let error t path fmt =
-  Fmt.kstrf (fun error ->
+  Fmt.kstrf
+    (fun error ->
       let logs =
         let filename = output_file t path in
-        if t.verbose || not (Sys.file_exists filename)
-        then Fmt.strf "%s\n" error
+        if t.verbose || not (Sys.file_exists filename) then
+          Fmt.strf "%s\n" error
         else
           let file = open_in filename in
           let output = string_of_channel file in
@@ -250,88 +248,88 @@ let error t path fmt =
       in
       let error =
         Fmt.strf "-- %s [%s] Failed --\n%s"
-          (short_string_of_path path) (doc_of_path t path) logs
+          (short_string_of_path path)
+          (doc_of_path t path) logs
       in
-      t.errors <- error :: t.errors;
-    ) fmt
+      t.errors <- error :: t.errors)
+    fmt
 
 let reset t = print t (fun ppf -> Fmt.string ppf "\r")
+
 let newline t = print t (fun ppf -> Fmt.string ppf "\n")
+
 let print_ch t ch = print t (fun ppf -> Fmt.string ppf ch)
 
 let print_full_result t p = function
-  | `Ok            ->
-    print t (fun ppf -> left left_c green_s ppf "[OK]");
-    print_info t p
+  | `Ok ->
+      print t (fun ppf -> left left_c green_s ppf "[OK]");
+      print_info t p
   | `Exn _ ->
-    print t (fun ppf -> left left_c red_s ppf "[FAIL]");
-    print_info t p;
-  | `Error _  ->
-    print t (fun ppf -> left left_c red_s ppf "[ERROR]");
-    print_info t p;
-  | `Skip          ->
-    print t (fun ppf -> left left_c yellow_s ppf "[SKIP]");
-    print_info t p
-  | `Todo _        ->
-    print t (fun ppf -> left left_c yellow_s ppf "[TODO]");
-    print_info t p
+      print t (fun ppf -> left left_c red_s ppf "[FAIL]");
+      print_info t p
+  | `Error _ ->
+      print t (fun ppf -> left left_c red_s ppf "[ERROR]");
+      print_info t p
+  | `Skip ->
+      print t (fun ppf -> left left_c yellow_s ppf "[SKIP]");
+      print_info t p
+  | `Todo _ ->
+      print t (fun ppf -> left left_c yellow_s ppf "[TODO]");
+      print_info t p
 
 let print_compact_result t = function
-  | `Exn _   -> print_ch t "F"
+  | `Exn _ -> print_ch t "F"
   | `Error _ -> print_ch t "E"
-  | `Skip    -> print_ch t "S"
-  | `Todo _  -> print_ch t "T"
-  | `Ok      -> print_ch t "."
+  | `Skip -> print_ch t "S"
+  | `Todo _ -> print_ch t "T"
+  | `Ok -> print_ch t "."
 
 let print_event t = function
   | `Start _ when t.compact -> ()
   | `Start p ->
-    print t (fun ppf -> left left_c yellow_s ppf " ...");
-    print_info t p;
-  | `Result (_, r) when t.compact ->
-    print_compact_result t r
+      print t (fun ppf -> left left_c yellow_s ppf " ...");
+      print_info t p
+  | `Result (_, r) when t.compact -> print_compact_result t r
   | `Result (p, r) ->
-    reset t;
-    print_full_result t p r;
-    newline t
+      reset t;
+      print_full_result t p r;
+      newline t
 
-let failure: run_result -> bool = function
-  | `Ok
-  | `Skip  -> false
-  | `Error _
-  | `Exn _
-  | `Todo _ -> true
+let failure : run_result -> bool = function
+  | `Ok | `Skip -> false
+  | `Error _ | `Exn _ | `Todo _ -> true
 
-let has_run: run_result -> bool = function
-  | `Ok
-  | `Error _
-  | `Exn _ -> true
-  | `Skip
-  | `Todo _    -> false
+let has_run : run_result -> bool = function
+  | `Ok | `Error _ | `Exn _ -> true
+  | `Skip | `Todo _ -> false
 
-let bt () = match Printexc.get_backtrace () with "" -> "" | s  -> "\n" ^ s
+let bt () = match Printexc.get_backtrace () with "" -> "" | s -> "\n" ^ s
+
 let exn path name err =
   let err = Printf.sprintf "%s%s" err (bt ()) in
   `Exn (path, name, err)
 
-let protect_test path (f:'a run): 'a rrun =
-  fun args ->
-    try f args; `Ok
-    with
-    | Check_error err ->
+let protect_test path (f : 'a run) : 'a rrun =
+ fun args ->
+  try
+    f args;
+    `Ok
+  with
+  | Check_error err ->
       let err = Printf.sprintf "Test error: %s%s" err (bt ()) in
       `Error (path, err)
-    | Failure f -> exn path "failure" f
-    | Invalid_argument f -> exn path "invalid" f
-    | e -> exn path "exception" (Printexc.to_string e)
+  | Failure f -> exn path "failure" f
+  | Invalid_argument f -> exn path "invalid" f
+  | e -> exn path "exception" (Printexc.to_string e)
 
 let perform_test t args (path, test) =
   print_event t (`Start path);
   let result = test args in
   (* Store errors *)
-  let () = match result with
+  let () =
+    match result with
     | `Exn (p, n, s) -> error t p "[%s] %s" n s
-    | `Error (p, s)  -> error t p "%s" s
+    | `Error (p, s) -> error t p "%s" s
     | _ -> ()
   in
   print_event t (`Result (path, result));
@@ -346,115 +344,98 @@ let with_redirect file fn =
   let fd_stderr = Unix.descr_of_out_channel stderr in
   let fd_old_stdout = Unix.dup fd_stdout in
   let fd_old_stderr = Unix.dup fd_stderr in
-  let fd_file = Unix.(openfile file [O_WRONLY; O_TRUNC; O_CREAT] 0o660) in
+  let fd_file = Unix.(openfile file [ O_WRONLY; O_TRUNC; O_CREAT ] 0o660) in
   Unix.dup2 fd_file fd_stdout;
   Unix.dup2 fd_file fd_stderr;
   Unix.close fd_file;
-  let r =
-    try `Ok (fn ())
-    with e -> `Error e in
+  let r = try `Ok (fn ()) with e -> `Error e in
   flush stdout;
   flush stderr;
   Unix.dup2 fd_old_stdout fd_stdout;
   Unix.dup2 fd_old_stderr fd_stderr;
   Unix.close fd_old_stdout;
   Unix.close fd_old_stderr;
-  match r with
-  | `Ok x -> x
-  | `Error e -> raise e
+  match r with `Ok x -> x | `Error e -> raise e
 
 let skip_fun _ = `Skip
 
-let skip_label (path, _) = path, skip_fun
+let skip_label (path, _) = (path, skip_fun)
 
 let filter_test (regexp, cases) (test : path * 'a rrun) =
   let Path (n, i), _ = test in
-  let regexp_match = function
-    | None -> true
-    | Some r -> Re.execp r n
-  in
-  let case_match = function
-    | None -> true
-    | Some set -> IntSet.mem i set
-  in
-  (regexp_match regexp) && (case_match cases)
+  let regexp_match = function None -> true | Some r -> Re.execp r n in
+  let case_match = function None -> true | Some set -> IntSet.mem i set in
+  regexp_match regexp && case_match cases
 
-let map_test f l = List.map (fun (path, test) -> path, f path test) l
+let map_test f l = List.map (fun (path, test) -> (path, f path test)) l
 
 let filter_tests ~subst path tests =
-  let tests = List.fold_left (fun acc test ->
-      if filter_test path test then
-        test :: acc
-      else if subst then
-        skip_label test :: acc
-      else
-        acc
-    ) [] tests in
+  let tests =
+    List.fold_left
+      (fun acc test ->
+        if filter_test path test then test :: acc
+        else if subst then skip_label test :: acc
+        else acc)
+      [] tests
+  in
   List.rev tests
 
-let redirect_test_output t path (f: 'a rrun) =
+let redirect_test_output t path (f : 'a rrun) =
   if t.verbose then f
   else fun args ->
     let output_file = output_file t path in
     with_redirect output_file (fun () ->
-      let result = f args in
-      begin match result with
+        let result = f args in
+        ( match result with
         | `Error (_path, str) -> Printf.printf "%s\n" str
         | `Exn (_path, n, str) -> Printf.printf "[%s] %s\n" n str
-        | `Ok | `Todo _ | `Skip -> ()
-      end;
-      result
-    )
+        | `Ok | `Todo _ | `Skip -> () );
+        result)
 
-let select_speed t path (f: 'a rrun): 'a rrun =
-  if compare_speed_level (speed_of_path t path) t.speed_level >= 0 then
-    f
-  else
-    skip_fun
+let select_speed t path (f : 'a rrun) : 'a rrun =
+  if compare_speed_level (speed_of_path t path) t.speed_level >= 0 then f
+  else skip_fun
 
-type result = {
-  success: int;
-  failures: int;
-  time: float
-}
+type result = { success : int; failures : int; time : float }
 
 (* Return the json for the api, dirty out, to avoid new dependencies *)
 let json_of_result r =
-  Printf.sprintf "{\"success\":%i,\"failures\":%i,\"time\":%f}"
-    r.success r.failures r.time
+  Printf.sprintf "{\"success\":%i,\"failures\":%i,\"time\":%f}" r.success
+    r.failures r.time
 
 let s = function 0 | 1 -> "" | _ -> "s"
 
 let show_result t result =
   (* Function to display errors for each test *)
-  let display_errors () = match result.failures with
+  let display_errors () =
+    match result.failures with
     | 0 -> ()
     | _ ->
-      if result.failures > 0 then
-        let print_error error = Printf.printf "%s\n" error in
-        if t.verbose || t.show_errors then
-          List.iter print_error (List.rev t.errors)
-        else
-          print_error (List.hd (List.rev t.errors))
+        if result.failures > 0 then
+          let print_error error = Printf.printf "%s\n" error in
+          if t.verbose || t.show_errors then
+            List.iter print_error (List.rev t.errors)
+          else print_error (List.hd (List.rev t.errors))
   in
   match t.json with
-  | true  -> Printf.printf "%s\n" (json_of_result result)
+  | true -> Printf.printf "%s\n" (json_of_result result)
   | false ->
-    if t.compact then newline t;
-    display_errors ();
-    let test_results ppf = match result.failures with
-      | 0 -> green_s ppf "Test Successful"
-      | n -> red     ppf "%d error%s!" n (s n)
-    in
-    let full_logs ppf =
-      if t.verbose then Fmt.string ppf ""
-      else
-        Fmt.pf ppf "The full test results are available in `%s`.\n"
-          (output_dir t)
-    in
-    if (not t.compact || result.failures > 0) then
-      Fmt.pr "%t%t in %.3fs. %d test%s run.\n%!"
-        full_logs test_results result.time result.success (s result.success)
+      if t.compact then newline t;
+      display_errors ();
+      let test_results ppf =
+        match result.failures with
+        | 0 -> green_s ppf "Test Successful"
+        | n -> red ppf "%d error%s!" n (s n)
+      in
+      let full_logs ppf =
+        if t.verbose then Fmt.string ppf ""
+        else
+          Fmt.pf ppf "The full test results are available in `%s`.\n"
+            (output_dir t)
+      in
+      if (not t.compact) || result.failures > 0 then
+        Fmt.pr "%t%t in %.3fs. %d test%s run.\n%!" full_logs test_results
+          result.time result.success (s result.success)
 
 let result t test args =
   prepare t;
@@ -469,53 +450,64 @@ let result t test args =
 
 let list_tests t () =
   let paths = List.sort Pervasives.compare t.paths in
-  List.iter (fun path ->
-      Fmt.(pf stdout) "%a    %s\n" (pp_path t) path (doc_of_path t path)
-    ) paths;
+  List.iter
+    (fun path ->
+      Fmt.(pf stdout) "%a    %s\n" (pp_path t) path (doc_of_path t path))
+    paths;
   0
 
 let validate_name name =
   let pattern = "^[a-zA-Z0-9_- ]+$" in
   let re = Re.(compile @@ Pcre.re pattern) in
   if not (Re.execp re name) then
-    let msg = Fmt.strf "%a %S is not a valid test label (must match %s)." red "Error:" name pattern in
+    let msg =
+      Fmt.strf "%a %S is not a valid test label (must match %s)." red "Error:"
+        name pattern
+    in
     Error msg
-  else
-    Ok ()
+  else Ok ()
 
-let register t name (ts: 'a test_case list) =
+let register t name (ts : 'a test_case list) =
   match (t, validate_name name) with
-  | Error error_acc, Error e -> Error (e::error_acc)
-  | Error error_acc, Ok ()   -> Error error_acc
-  | Ok _, Error e            -> Error [e]
+  | Error error_acc, Error e -> Error (e :: error_acc)
+  | Error error_acc, Ok () -> Error error_acc
+  | Ok _, Error e -> Error [ e ]
   | Ok t, Ok () ->
-    let max_label = max t.max_label (String.length name) in
-    let paths = Hashtbl.create 16 in
-    let docs = Hashtbl.create 16 in
-    let speeds = Hashtbl.create 16 in
-    let ts = List.mapi (fun i (doc, speed, test) ->
-        let path = Path (name, i) in
-        let doc =
-          if doc = "" || doc.[String.length doc - 1] = '.' then doc
-          else doc ^ "." in
-        Hashtbl.add paths path true;
-        Hashtbl.add docs path doc;
-        Hashtbl.add speeds path speed;
-        path, protect_test path test
-      ) ts in
-    let tests = t.tests @ ts in
-    let paths = Hashtbl.fold (fun k _ acc -> k :: acc) paths [] in
-    let paths = t.paths @ paths in
-    let doc p = try Some (Hashtbl.find docs p) with Not_found -> t.doc p in
-    let speed p = try Some (Hashtbl.find speeds p) with Not_found -> t.speed p in
-    Ok { t with paths; tests; doc; speed; max_label; }
+      let max_label = max t.max_label (String.length name) in
+      let paths = Hashtbl.create 16 in
+      let docs = Hashtbl.create 16 in
+      let speeds = Hashtbl.create 16 in
+      let ts =
+        List.mapi
+          (fun i (doc, speed, test) ->
+            let path = Path (name, i) in
+            let doc =
+              if doc = "" || doc.[String.length doc - 1] = '.' then doc
+              else doc ^ "."
+            in
+            Hashtbl.add paths path true;
+            Hashtbl.add docs path doc;
+            Hashtbl.add speeds path speed;
+            (path, protect_test path test))
+          ts
+      in
+      let tests = t.tests @ ts in
+      let paths = Hashtbl.fold (fun k _ acc -> k :: acc) paths [] in
+      let paths = t.paths @ paths in
+      let doc p = try Some (Hashtbl.find docs p) with Not_found -> t.doc p in
+      let speed p =
+        try Some (Hashtbl.find speeds p) with Not_found -> t.speed p
+      in
+      Ok { t with paths; tests; doc; speed; max_label }
 
 exception Test_error
 
 let apply fn t test_dir verbose compact show_errors quick json =
   let show_errors = show_errors in
   let speed_level = if quick then `Quick else `Slow in
-  let t = { t with verbose; compact; test_dir; json; show_errors; speed_level } in
+  let t =
+    { t with verbose; compact; test_dir; json; show_errors; speed_level }
+  in
   fn t
 
 let run_registred_tests t () args =
@@ -526,9 +518,11 @@ let run_registred_tests t () args =
 let run_subtest t labels () args =
   let is_empty = filter_tests ~subst:false labels t.tests = [] in
   if is_empty then (
-    Fmt.(pf stderr) "%a\n" red "Invalid request (no tests to run, filter skipped everything)!";
-    exit 1
-  ) else
+    Fmt.(pf stderr)
+      "%a\n" red
+      "Invalid request (no tests to run, filter skipped everything)!";
+    exit 1 )
+  else
     let tests = filter_tests ~subst:true labels t.tests in
     let result = result t tests args in
     show_result t result;
@@ -538,55 +532,54 @@ open Cmdliner
 
 let json =
   let doc = "Display JSON for the results, to be used by a script." in
-  Arg.(value & flag & info ["json"] ~docv:"" ~doc)
+  Arg.(value & flag & info [ "json" ] ~docv:"" ~doc)
 
 let test_dir =
   let fname_concat l = List.fold_left Filename.concat "" l in
-  let default_dir = fname_concat [Sys.getcwd (); "_build"; "_tests"] in
+  let default_dir = fname_concat [ Sys.getcwd (); "_build"; "_tests" ] in
   let doc = "Where to store the log files of the tests." in
-  Arg.(value & opt dir default_dir & info ["o"] ~docv:"DIR" ~doc)
+  Arg.(value & opt dir default_dir & info [ "o" ] ~docv:"DIR" ~doc)
 
 let verbose =
   let env = Arg.env_var "ALCOTEST_VERBOSE" in
   let doc =
-    "Display the test outputs. $(b,WARNING:) when using this option \
-     the output logs will not be available for further inspection."
- in
-  Arg.(value & flag & info ~env ["v"; "verbose"] ~docv:"" ~doc)
+    "Display the test outputs. $(b,WARNING:) when using this option the \
+     output logs will not be available for further inspection."
+  in
+  Arg.(value & flag & info ~env [ "v"; "verbose" ] ~docv:"" ~doc)
 
 let compact =
   let env = Arg.env_var "ALCOTEST_COMPACT" in
-  let doc =
-    "Compact the output of the tests"
- in
-  Arg.(value & flag & info ~env ["c"; "compact"] ~docv:"" ~doc)
+  let doc = "Compact the output of the tests" in
+  Arg.(value & flag & info ~env [ "c"; "compact" ] ~docv:"" ~doc)
 
 let show_errors =
   let env = Arg.env_var "ALCOTEST_SHOW_ERRORS" in
   let doc = "Display the test errors." in
-  Arg.(value & flag & info ~env ["e"; "show-errors"] ~docv:"" ~doc)
+  Arg.(value & flag & info ~env [ "e"; "show-errors" ] ~docv:"" ~doc)
 
 let quicktests =
   let env = Arg.env_var "ALCOTEST_QUICK_TESTS" in
   let doc = "Run only the quick tests." in
-  Arg.(value & flag & info ~env ["q"; "quick-tests"] ~docv:"" ~doc)
+  Arg.(value & flag & info ~env [ "q"; "quick-tests" ] ~docv:"" ~doc)
 
 let of_env t =
-  Term.(pure (apply (fun t -> t) t)
-        $ test_dir $ verbose $ compact $ show_errors $ quicktests $ json)
+  Term.(
+    pure (apply (fun t -> t) t)
+    $ test_dir $ verbose $ compact $ show_errors $ quicktests $ json)
 
-let set_color style_renderer =
-  Fmt_tty.setup_std_outputs ?style_renderer ()
+let set_color style_renderer = Fmt_tty.setup_std_outputs ?style_renderer ()
 
 let set_color = Term.(const set_color $ Fmt_cli.style_renderer ())
 
 let default_cmd t args =
   let doc = "Run all the tests." in
-  Term.(pure run_registred_tests $ of_env t $ set_color $ args),
-  Term.info t.name ~version:"%%VERSION%%" ~doc
+  ( Term.(pure run_registred_tests $ of_env t $ set_color $ args),
+    Term.info t.name ~version:"%%VERSION%%" ~doc )
 
 let regex =
-  let parse s = try Ok (Re.(compile @@ Pcre.re s)) with
+  let parse s =
+    try Ok Re.(compile @@ Pcre.re s) with
     | Re.Perl.Parse_error -> Error (`Msg "Perl-compatible regexp parse error")
     | Re.Perl.Not_supported -> Error (`Msg "unsupported regexp feature")
   in
@@ -598,23 +591,27 @@ exception Invalid_format
 let int_range_list =
   let parse s =
     let set = ref IntSet.empty in
-    let acc i = (set := IntSet.add i (!set)) in
+    let acc i = set := IntSet.add i !set in
     let ranges = String.cuts ~sep:"," s in
     let process_range s =
-      let bounds = String.cuts ~sep:".." s |> List.map (String.to_int) in
+      let bounds = String.cuts ~sep:".." s |> List.map String.to_int in
       match bounds with
-      | [Some i] -> acc i
-      | [Some lower; Some upper] when lower <= upper ->
-        for i = lower to upper do
-          acc i
-        done
+      | [ Some i ] -> acc i
+      | [ Some lower; Some upper ] when lower <= upper ->
+          for i = lower to upper do
+            acc i
+          done
       | _ -> raise Invalid_format
     in
     match List.iter process_range ranges with
-    | () -> Ok (!set)
-    | exception Invalid_format -> Error (`Msg "must be a comma-separated list of integers / integer ranges")
+    | () -> Ok !set
+    | exception Invalid_format ->
+        Error
+          (`Msg "must be a comma-separated list of integers / integer ranges")
   in
-  let print ppf set = Fmt.pf ppf "%a" Fmt.(braces @@ list ~sep:comma int) (IntSet.elements set) in
+  let print ppf set =
+    Fmt.pf ppf "%a" Fmt.(braces @@ list ~sep:comma int) (IntSet.elements set)
+  in
   Arg.conv (parse, print)
 
 let test_cmd t args =
@@ -624,91 +621,106 @@ let test_cmd t args =
     Arg.(value & pos 0 (some regex) None & info [] ~doc ~docv:"NAME_REGEX")
   in
   let testcase =
-    let doc = "A comma-separated list of test case numbers (and ranges of numbers) to run, e.g: '4,6-10,19'" in
-    Arg.(value & pos 1 (some int_range_list) None & info [] ~doc ~docv:"TESTCASES")
+    let doc =
+      "A comma-separated list of test case numbers (and ranges of numbers) to \
+       run, e.g: '4,6-10,19'"
+    in
+    Arg.(
+      value & pos 1 (some int_range_list) None & info [] ~doc ~docv:"TESTCASES")
   in
-  let label = Term.(pure (fun n t -> n, t) $ testname $ testcase) in
-  Term.(pure run_subtest $ of_env t $ label $ set_color $ args),
-  Term.info "test" ~doc
+  let label = Term.(pure (fun n t -> (n, t)) $ testname $ testcase) in
+  ( Term.(pure run_subtest $ of_env t $ label $ set_color $ args),
+    Term.info "test" ~doc )
 
 let list_cmd t =
   let doc = "List all available tests." in
-  Term.(pure list_tests $ of_env t $ set_color),
-  Term.info "list" ~doc
+  (Term.(pure list_tests $ of_env t $ set_color), Term.info "list" ~doc)
 
 let random_state = Random.State.make_self_init ()
 
-let run_with_args ?(and_exit = true) ?argv name args (tl: 'a test list) =
-  let run_id =
-    Uuidm.v4_gen random_state ()
-    |> Uuidm.to_string ~upper:true in
-  let t = { (empty ()) with run_id=run_id} in
-  let t = List.fold_left (fun t (name, tests) -> register t name tests) (Ok t) tl in
+let run_with_args ?(and_exit = true) ?argv name args (tl : 'a test list) =
+  let run_id = Uuidm.v4_gen random_state () |> Uuidm.to_string ~upper:true in
+  let t = { (empty ()) with run_id } in
+  let t =
+    List.fold_left (fun t (name, tests) -> register t name tests) (Ok t) tl
+  in
   match t with
   | Error error_acc ->
-    Fmt.(pf stderr) "%a\n" Fmt.(list string) (List.rev error_acc);
-    exit 1
-  | Ok t ->
-    Fmt.(pf stdout) "Testing %a.\n" bold_s name;
-    Fmt.(pf stdout) "This run has ID `%s`.\n" run_id;
-    let choices = [
-      list_cmd t;
-      test_cmd t args;
-    ] in
-    match Term.eval_choice ?argv (default_cmd t args) choices with
-    | `Ok 0    -> if and_exit then exit 0 else ()
-    | `Error _ -> if and_exit then exit 1 else raise Test_error
-    | `Ok i    -> if and_exit then exit i else raise Test_error
-    | _        -> if and_exit then exit 0 else ()
+      Fmt.(pf stderr) "%a\n" Fmt.(list string) (List.rev error_acc);
+      exit 1
+  | Ok t -> (
+      Fmt.(pf stdout) "Testing %a.\n" bold_s name;
+      Fmt.(pf stdout) "This run has ID `%s`.\n" run_id;
+      let choices = [ list_cmd t; test_cmd t args ] in
+      match Term.eval_choice ?argv (default_cmd t args) choices with
+      | `Ok 0 -> if and_exit then exit 0 else ()
+      | `Error _ -> if and_exit then exit 1 else raise Test_error
+      | `Ok i -> if and_exit then exit i else raise Test_error
+      | _ -> if and_exit then exit 0 else () )
 
 let run ?and_exit ?argv name tl =
   run_with_args ?and_exit ?argv name (Term.pure ()) tl
 
 module type TESTABLE = sig
   type t
-  val pp: t Fmt.t
-  val equal: t -> t -> bool
+
+  val pp : t Fmt.t
+
+  val equal : t -> t -> bool
 end
 
 type 'a testable = (module TESTABLE with type t = 'a)
 
-let pp (type a) (t: a testable) = let (module T) = t in T.pp
+let pp (type a) (t : a testable) =
+  let (module T) = t in
+  T.pp
 
-let equal (type a) (t: a testable) = let (module T) = t in T.equal
+let equal (type a) (t : a testable) =
+  let (module T) = t in
+  T.equal
 
 let isnan f = FP_nan = classify_float f
 
-let testable (type a) (pp: a Fmt.t) (equal: a -> a -> bool) : a testable =
-  let module M = struct type t = a let pp = pp let equal = equal end
-  in (module M)
+let testable (type a) (pp : a Fmt.t) (equal : a -> a -> bool) : a testable =
+  let module M = struct
+    type t = a
 
-let int32 = testable Fmt.int32 (=)
+    let pp = pp
 
-let int64 = testable Fmt.int64 (=)
+    let equal = equal
+  end in
+  (module M)
 
-let int = testable Fmt.int (=)
+let int32 = testable Fmt.int32 ( = )
+
+let int64 = testable Fmt.int64 ( = )
+
+let int = testable Fmt.int ( = )
 
 let float eps =
-  let same x y = (isnan x && isnan y) ||
-                 (* compare infinities *)
-                  x = y ||
-                  abs_float (x -. y) <= eps
+  let same x y =
+    (isnan x && isnan y)
+    (* compare infinities *)
+    || x = y
+    || abs_float (x -. y) <= eps
   in
   testable Fmt.float same
 
-let char = testable Fmt.char (=)
+let char = testable Fmt.char ( = )
 
-let string = testable Fmt.string (=)
+let string = testable Fmt.string ( = )
 
-let bool = testable Fmt.bool (=)
+let bool = testable Fmt.bool ( = )
 
-let unit = testable (Fmt.unit "()") (=)
+let unit = testable (Fmt.unit "()") ( = )
 
 let list e =
-  let rec eq l1 l2 = match (l1, l2) with
-    | (x::xs, y::ys) -> equal e x y && eq xs ys
-    | ([], []) -> true
-    | _ -> false in
+  let rec eq l1 l2 =
+    match (l1, l2) with
+    | x :: xs, y :: ys -> equal e x y && eq xs ys
+    | [], [] -> true
+    | _ -> false
+  in
   testable (Fmt.Dump.list (pp e)) eq
 
 let slist (type a) (a : a testable) compare =
@@ -718,9 +730,10 @@ let slist (type a) (a : a testable) compare =
 
 let array e =
   let eq a1 a2 =
-    let (m, n) = Array.(length a1, length a2) in
+    let m, n = Array.(length a1, length a2) in
     let rec go i = i = m || (equal e a1.(i) a2.(i) && go (i + 1)) in
-    m = n && go 0 in
+    m = n && go 0
+  in
   testable (Fmt.Dump.array (pp e)) eq
 
 let pair a b =
@@ -728,37 +741,44 @@ let pair a b =
   testable (Fmt.Dump.pair (pp a) (pp b)) eq
 
 let option e =
-  let eq x y = match (x, y) with
-    | (Some a, Some b) -> equal e a b
-    | (None, None) -> true
-    | _ -> false in
+  let eq x y =
+    match (x, y) with
+    | Some a, Some b -> equal e a b
+    | None, None -> true
+    | _ -> false
+  in
   testable (Fmt.Dump.option (pp e)) eq
 
 let result a e =
   let eq x y =
     match (x, y) with
-    | (Ok x, Ok y) -> equal a x y
-    | (Error x, Error y) -> equal e x y
-    | _ -> false in
+    | Ok x, Ok y -> equal a x y
+    | Error x, Error y -> equal e x y
+    | _ -> false
+  in
   testable (Fmt.Dump.result ~ok:(pp a) ~error:(pp e)) eq
 
-let of_pp pp = testable pp (=)
+let of_pp pp = testable pp ( = )
 
 let pass (type a) =
   let module M = struct
     type t = a
+
     let pp fmt _ = Fmt.string fmt "Alcotest.pass"
+
     let equal _ _ = true
   end in
-  (module M: TESTABLE with type t = M.t)
+  (module M : TESTABLE with type t = M.t)
 
 let reject (type a) =
   let module M = struct
     type t = a
+
     let pp fmt _ = Fmt.string fmt "Alcotest.reject"
+
     let equal _ _ = false
   end in
-  (module M: TESTABLE with type t = M.t)
+  (module M : TESTABLE with type t = M.t)
 
 let show_line msg =
   line Fmt.stderr ~color:`Yellow '-';
@@ -777,31 +797,40 @@ let fail msg =
   show_line msg;
   check_err "Error %s." msg
 
-let failf fmt =
-  Fmt.kstrf fail fmt
+let failf fmt = Fmt.kstrf fail fmt
 
 let neg t = testable (pp t) (fun x y -> not (equal t x y))
 
 let collect_exception f =
-  try f (); None with e -> Some e
+  try
+    f ();
+    None
+  with e -> Some e
 
 let check_raises msg exn f =
   show_line msg;
   match collect_exception f with
-    None ->
-    check_err "Fail %s: expecting %s, got nothing." msg (Printexc.to_string exn)
+  | None ->
+      check_err "Fail %s: expecting %s, got nothing." msg
+        (Printexc.to_string exn)
   | Some e ->
-    if e <> exn then
-      check_err "Fail %s: expecting %s, got %s."
-        msg (Printexc.to_string exn) (Printexc.to_string e)
+      if e <> exn then
+        check_err "Fail %s: expecting %s, got %s." msg (Printexc.to_string exn)
+          (Printexc.to_string e)
 
-let line (oc:out_channel) ?color c =
-  let color = match color with
-    | None         -> None
-    | Some `Blue   -> Some `Cyan
+let line (oc : out_channel) ?color c =
+  let color =
+    match color with
+    | None -> None
+    | Some `Blue -> Some `Cyan
     | Some `Yellow -> Some `Yellow
   in
-  let str: string = Fmt.(to_to_string @@ fun ppf -> line ppf ?color) c in
+  let str : string =
+    Fmt.(
+      to_to_string @@ fun ppf ->
+      line ppf ?color)
+      c
+  in
   Printf.fprintf oc "%s" str
 
 let () = at_exit (Format.pp_print_flush Format.err_formatter)

--- a/src/alcotest.mli
+++ b/src/alcotest.mli
@@ -29,7 +29,7 @@
 
     {e Release %%VERSION%% } *)
 
-type speed_level = [`Quick | `Slow]
+type speed_level = [ `Quick | `Slow ]
 (** Speed level of a test. Tests marked as [`Quick] are always run. Tests marked
    as [`Slow] are skipped when the `-q` flag is passed. *)
 
@@ -38,7 +38,7 @@ type 'a test_case = string * speed_level * ('a -> unit)
     level and a function to execute. Typically, the testing function calls the
     helper functions provided below (such as [check] and [fail]). *)
 
-val test_case: string -> speed_level -> ('a -> unit) -> 'a test_case
+val test_case : string -> speed_level -> ('a -> unit) -> 'a test_case
 (** [test_case n s f] is the test case [n] running at speed [s] using
     the function [f]. *)
 
@@ -49,8 +49,8 @@ type 'a test = string * 'a test_case list
 exception Test_error
 (** The exception return by {!run} in case of errors. *)
 
-val run: ?and_exit:bool -> ?argv:string array ->
-  string -> unit test list -> unit
+val run :
+  ?and_exit:bool -> ?argv:string array -> string -> unit test list -> unit
 (** [run n t] runs the test suite [t]. [n] is the name of the
     tested library.
 
@@ -68,8 +68,13 @@ val run: ?and_exit:bool -> ?argv:string array ->
     an error, [~argv:[| "--verbose" |]] will have no effect, and [~argv:[|
     "ignored"; "--verbose" |]] will successfully pass the verbose option. *)
 
-val run_with_args: ?and_exit:bool -> ?argv:string array ->
-  string -> 'a Cmdliner.Term.t -> 'a test list -> unit
+val run_with_args :
+  ?and_exit:bool ->
+  ?argv:string array ->
+  string ->
+  'a Cmdliner.Term.t ->
+  'a test list ->
+  unit
 (** [run_with_args n a t] Similar to [run a t] but take an extra
     argument [a]. Every test function will receive as arguement the
     evaluation of the [Cdmliner] term [a]: this is useful to configure
@@ -80,16 +85,14 @@ val run_with_args: ?and_exit:bool -> ?argv:string array ->
 (** [TESTABLE] provides an abstract description for testable
     values. *)
 module type TESTABLE = sig
-
   type t
   (** The type to test. *)
 
-  val pp: t Fmt.t
+  val pp : t Fmt.t
   (** A way to pretty-print the value. *)
 
-  val equal: t -> t -> bool
+  val equal : t -> t -> bool
   (** Test for equality between two values. *)
-
 end
 
 type 'a testable = (module TESTABLE with type t = 'a)
@@ -105,78 +108,78 @@ val pp : 'a testable -> 'a Fmt.t
 val equal : 'a testable -> 'a -> 'a -> bool
 (** [equal t] is [t]'s equality. *)
 
-val bool: bool testable
+val bool : bool testable
 (** [bool] tests booleans. *)
 
-val int: int testable
+val int : int testable
 (** [int] tests integers. *)
 
-val int32: int32 testable
+val int32 : int32 testable
 (** [int32] tests 32-bit integers. *)
 
-val int64: int64 testable
+val int64 : int64 testable
 (** [int64] tests 64-bit integers. *)
 
-val float: float -> float testable
+val float : float -> float testable
 (** [float] tests floats with specified absolute error. *)
 
-val char: char testable
+val char : char testable
 (** [char] tests characters. *)
 
-val string: string testable
+val string : string testable
 (** [string] tests OCaml strings. *)
 
-val unit: unit testable
+val unit : unit testable
 (** [unit] tests unit values (useful for functions with side-effects). *)
 
-val list: 'a testable -> 'a list testable
+val list : 'a testable -> 'a list testable
 (** [list t] tests lists of [t]s. *)
 
-val slist: 'a testable -> ('a -> 'a -> int) -> 'a list testable
+val slist : 'a testable -> ('a -> 'a -> int) -> 'a list testable
 (** [slist t comp] tests sorted lists of [t]s. The list are sorted
     using [comp]. *)
 
 val array : 'a testable -> 'a array testable
 (** [array t] tests arrays of [t]s. *)
 
-val option: 'a testable -> 'a option testable
+val option : 'a testable -> 'a option testable
 (** [option t] tests optional [t]s. *)
 
 val result : 'a testable -> 'e testable -> ('a, 'e) result testable
 (** [result t e] tests [t]s on success and [e]s on failure. *)
 
-val pair: 'a testable -> 'b testable -> ('a * 'b) testable
+val pair : 'a testable -> 'b testable -> ('a * 'b) testable
 (** [pair a b] tests pairs of [a]s and [b]s. *)
 
-val of_pp: 'a Fmt.t -> 'a testable
+val of_pp : 'a Fmt.t -> 'a testable
 (** [of_pp pp] tests values which can be printed using [pp] and
     compared using {!Pervasives.compare} *)
 
-val pass: 'a testable
+val pass : 'a testable
 (** [pass] tests values of any type and always succeeds. *)
 
-val reject: 'a testable
+val reject : 'a testable
 (** [reject] tests values of any type and always fails. *)
 
-val check: 'a testable -> string -> 'a -> 'a -> unit
+val check : 'a testable -> string -> 'a -> 'a -> unit
 (** Check that two values are equal. *)
 
-val fail: string -> 'a
+val fail : string -> 'a
 (** Simply fail. *)
 
-val failf: ('a, Format.formatter, unit, 'b) format4 -> 'a
+val failf : ('a, Format.formatter, unit, 'b) format4 -> 'a
 (** Simply fail with a formatted message. *)
 
-val neg: 'a testable -> 'a testable
+val neg : 'a testable -> 'a testable
 (** [neg t] is [t]'s negation: it is [true] when [t] is [false] and it
     is [false] when [t] is [true]. *)
 
-val check_raises: string -> exn -> (unit -> unit) -> unit
+val check_raises : string -> exn -> (unit -> unit) -> unit
 (** Check that an exception is raised. *)
 
 (** {2 Deprecated} *)
 
-val line: out_channel -> ?color:[`Blue|`Yellow] -> char -> unit
+val line : out_channel -> ?color:[ `Blue | `Yellow ] -> char -> unit
 (** @deprecated
     You should write your own line function. For instance:
 {[


### PR DESCRIPTION
I suggest the use of ocamlformat 0.10, now that it has been released.

Big QOL improvement at the cost of a big diff.