### PR TITLE
remove result dependency

### DIFF
--- a/alcotest-async.opam
+++ b/alcotest-async.opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "dune"  {build}
   "ocaml" {>= "4.03.0"}
-  "alcotest"
+  "alcotest" {= version}
   "async_unix" {>= "v0.9.0"}
   "core_kernel" {>= "v0.9.0"}
 ]

--- a/alcotest-lwt.opam
+++ b/alcotest-lwt.opam
@@ -15,8 +15,8 @@ build: [
 
 depends: [
   "dune"  {build}
-  "ocaml" {>= "4.02.3"}
-  "alcotest"
+  "ocaml" {>= "4.03.0"}
+  "alcotest" {= version}
   "lwt" "logs"
 ]
 

--- a/alcotest.opam
+++ b/alcotest.opam
@@ -15,10 +15,9 @@ build: [
 
 depends: [
   "dune"  {build & >= "1.1.0"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.03.0"}
   "fmt"   {>= "0.8.0"}
   "astring"
-  "result"
   "cmdliner"
   "uuidm"
 ]

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -683,7 +683,7 @@ let option e =
   testable (Fmt.Dump.option (pp e)) eq
 
 let result a e =
-  let eq x y = let open Result in
+  let eq x y =
     match (x, y) with
     | (Ok x, Ok y) -> equal a x y
     | (Error x, Error y) -> equal e x y

--- a/src/alcotest.mli
+++ b/src/alcotest.mli
@@ -138,7 +138,7 @@ val array : 'a testable -> 'a array testable
 val option: 'a testable -> 'a option testable
 (** [option t] tests optional [t]s. *)
 
-val result : 'a testable -> 'e testable -> ('a, 'e) Result.result testable
+val result : 'a testable -> 'e testable -> ('a, 'e) result testable
 (** [result t e] tests [t]s on success and [e]s on failure. *)
 
 val pair: 'a testable -> 'b testable -> ('a * 'b) testable

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,3 @@
 (library
  (public_name alcotest)
- (libraries   fmt astring result cmdliner fmt.cli fmt.tty uuidm))
+ (libraries   fmt astring cmdliner fmt.cli fmt.tty uuidm))


### PR DESCRIPTION
also bump minimal ocaml to 4.03.0 (CI tests 4.04+ only :/); and require `= version` in alcotest-{lwt,async} packages