### PR TITLE
Report real time rather than system time

### DIFF
--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -445,11 +445,11 @@ let show_result t result =
 
 let result t test args =
   prepare t;
-  let start_time = Sys.time () in
+  let start_time = Unix.time () in
   let test = map_test (redirect_test_output t) test in
   let test = map_test (select_speed t) test in
   let results = perform_tests t test args in
-  let time = Sys.time () -. start_time in
+  let time = Unix.time () -. start_time in
   let success = List.length (List.filter has_run results) in
   let failures = List.filter failure results in
   { time; success; failures = List.length failures }


### PR DESCRIPTION
This is a candidate solution for #128.

Currently the test length is measured in CPU time rather than real time, leading to unintuitive output when running tests that are not CPU-bound (particularly Lwt tests). This changes the internals to measure time with `Unix.time` instead.

Original behaviour:
```
let () =
  Alcotest.run "alcotest" [
      ("bar1", [ Alcotest.test_case "unix" `Quick (fun () -> Unix.sleep 1)]);
      ("foo1", [ Alcotest_lwt.test_case "lwt" `Quick (fun _ () -> Lwt_unix.sleep 1.)]);
    ]

Test Successful in 0.000s. 2 tests run.
```
New behaviour:
```
Test Successful in 2.000s. 2 tests run.
```