### PR TITLE
Add examples of Alcotest-lwt usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ tests to run.
 
 ### Examples
 
-A simple example:
+A simple example (taken from `examples/simple.ml`):
 
 ```ocaml
 (* Build with `ocamlbuild -pkg alcotest simple.byte` *)

--- a/examples/lwt/dune
+++ b/examples/lwt/dune
@@ -1,0 +1,4 @@
+(tests
+ (names test)
+ (package alcotest-lwt)
+ (libraries alcotest-lwt))

--- a/examples/lwt/test.ml
+++ b/examples/lwt/test.ml
@@ -1,0 +1,103 @@
+(*
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>
+*)
+
+open Lwt.Infix
+
+exception Library_exception
+
+module To_test = struct
+  let lowercase = String.lowercase_ascii
+
+  let lowercase_lwt s = Lwt.return (lowercase s)
+
+  let exn () = raise Library_exception
+
+  let exn_lwt_toplevel () : unit Lwt.t = raise Library_exception
+
+  let exn_lwt_internal () : unit Lwt.t = Lwt.return (raise Library_exception)
+end
+
+(* The tests *)
+let test_lowercase () =
+  Alcotest.(check string) "same string" "hello!" (To_test.lowercase "hELLO!")
+
+let test_lowercase_lwt _ () =
+  To_test.lowercase_lwt "hELLO!"
+  >|= Alcotest.(check string) "same string" "hello!"
+
+let test_exn () =
+  Alcotest.check_raises "custom exception" Library_exception To_test.exn
+
+let lwt_check_raises f =
+  Lwt.catch
+    (fun () ->
+      f () >|= fun () ->
+      `Ok)
+    (function e -> Lwt.return @@ `Error e)
+  >|= function
+  | `Ok -> Alcotest.fail "No exception was thrown"
+  | `Error Library_exception -> Alcotest.(check pass) "Correct exception" () ()
+  | `Error _ -> Alcotest.fail "Incorrect exception was thrown"
+
+let test_exn_lwt_toplevel _ () = lwt_check_raises To_test.exn_lwt_toplevel
+
+let test_exn_lwt_internal _ () = lwt_check_raises To_test.exn_lwt_internal
+
+let switch = ref None
+
+let test_switch_alloc s () =
+  Lwt.return_unit >|= fun () ->
+  switch := Some s;
+  Alcotest.(check bool)
+    "Passed switch is initially on" (Lwt_switch.is_on s) true
+
+let test_switch_dealloc _ () =
+  Lwt.return_unit >|= fun () ->
+  match !switch with
+  | None -> Alcotest.fail "No switch left by `test_switch_alloc` test"
+  | Some s ->
+      Alcotest.(check bool)
+        "Switch is disabled after test" (Lwt_switch.is_on s) false
+
+(* Run it *)
+let () =
+  Alcotest.run "LwtUtils"
+    [ ( "basic",
+        [ Alcotest.test_case "Plain" `Quick test_lowercase;
+          Alcotest_lwt.test_case "Lwt" `Quick test_lowercase_lwt
+        ] );
+      ( "exceptions",
+        [ Alcotest.test_case "Plain" `Quick test_exn;
+          Alcotest_lwt.test_case "Lwt toplevel" `Quick test_exn_lwt_toplevel;
+          Alcotest_lwt.test_case "Lwt internal" `Quick test_exn_lwt_internal
+        ] );
+      ( "switches",
+        [ Alcotest_lwt.test_case "Allocate resource" `Quick test_switch_alloc;
+          Alcotest_lwt.test_case "Check resource is deallocated" `Quick
+            test_switch_dealloc
+        ] )
+    ]

--- a/examples/simple.ml
+++ b/examples/simple.ml
@@ -25,27 +25,43 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org/>
 *)
 
-(* Build with
- * ocamlbuild -pkg alcotest simple.byte *)
-
 (* A module with functions to test *)
 module To_test = struct
-  let capit letter = Astring.Char.Ascii.uppercase letter
+  let lowercase = String.lowercase_ascii
 
-  let plus int_list = List.fold_left (fun a b -> a + b) 0 int_list
+  let capitalize = String.capitalize_ascii
+
+  let str_concat = String.concat ""
+
+  let list_concat = List.append
 end
 
 (* The tests *)
-let capit () = Alcotest.(check char) "Check A" 'A' (To_test.capit 'a')
+let test_lowercase () =
+  Alcotest.(check string) "same string" "hello!" (To_test.lowercase "hELLO!")
 
-let plus () =
-  Alcotest.(check int) "Sum equals to 7" 7 (To_test.plus [ 1; 1; 2; 3 ])
+let test_capitalize () =
+  Alcotest.(check string) "same string" "World." (To_test.capitalize "world.")
 
-let test_set =
-  [ ("\xF0\x9F\x90\xAB  Capitalize", `Quick, capit);
-    ("Add entries", `Slow, plus)
-  ]
+let test_str_concat () =
+  Alcotest.(check string)
+    "same string" "foobar"
+    (To_test.str_concat [ "foo"; "bar" ])
+
+let test_list_concat () =
+  Alcotest.(check (list int))
+    "same lists" [ 1; 2; 3 ]
+    (To_test.list_concat [ 1 ] [ 2; 3 ])
 
 (* Run it *)
 let () =
-  Alcotest.run "My first test" [ ("test_1", test_set); ("test_2", test_set) ]
+  Alcotest.run "Utils"
+    [ ( "string-case",
+        [ Alcotest.test_case "Lower case" `Quick test_lowercase;
+          Alcotest.test_case "Capitalization" `Quick test_capitalize
+        ] );
+      ( "string-concat",
+        [ Alcotest.test_case "String mashing" `Quick test_str_concat ] );
+      ( "list-concat",
+        [ Alcotest.test_case "List mashing" `Slow test_list_concat ] )
+    ]


### PR DESCRIPTION
- Updates the `simple.ml` to match the example given in the README
- Adds an additional set of examples using Lwt. These will provide a useful point-of-reference for any future suggestions/improvements to the API