### PR TITLE
Generalise test logic on a concurrency monad

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ let test_lwt switch () =
   Lwt_unix.sleep 10.
 
 let () =
-  Alcotest.run "foo" [
+  Lwt_main.run @@ Alcotest_lwt.run "foo" [
     "all", [
       Alcotest_lwt.test_case "one" `Quick test_lwt
     ]

--- a/async/alcotest_async.ml
+++ b/async/alcotest_async.ml
@@ -2,7 +2,7 @@ open Core
 open Async_kernel
 open Async_unix
 
-module Tester = Alcotest.MonadicTester (struct
+module Tester = Alcotest.Make (struct
   include Deferred
 
   let bind x f = bind x ~f

--- a/async/alcotest_async.ml
+++ b/async/alcotest_async.ml
@@ -2,14 +2,23 @@ open Core
 open Async_kernel
 open Async_unix
 
-let run timeout name fn args =
-  Thread_safe.block_on_async_exn (fun () ->
-      Clock.with_timeout timeout (fn args) >>| function
-      | `Result x -> x
-      | `Timeout ->
-          Alcotest.fail
-            (Printf.sprintf "%s timed out after %s" name
-               (Time.Span.to_string_hum timeout)))
+module Tester = Alcotest.MonadicTester (struct
+  include Deferred
+
+  let bind x f = bind x ~f
+end)
+
+include Tester
+
+let test_case' n s f = test_case n s (fun x -> Deferred.return (f x))
+
+let run_test timeout name fn args =
+  Clock.with_timeout timeout (fn args) >>| function
+  | `Result x -> x
+  | `Timeout ->
+      Alcotest.fail
+        (Printf.sprintf "%s timed out after %s" name
+           (Time.Span.to_string_hum timeout))
 
 let test_case ?(timeout = sec 2.) name s f =
-  Alcotest.test_case name s (run timeout name f)
+  test_case name s (run_test timeout name f)

--- a/async/alcotest_async.mli
+++ b/async/alcotest_async.mli
@@ -14,12 +14,16 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-(** [Alcotest_async] allows to defines tests which returns an Async deferred.
-    {!run} will schedule these deferreds and return their results. *)
+(** [Alcotest_async] enables testing functions which return an Async deferred.
+    {!run} returns a deferred which will run the tests when scheduled. *)
+
+include Alcotest.TESTER with type return = unit Async_kernel.Deferred.t
 
 val test_case :
   ?timeout:Core_kernel.Time.Span.t ->
   string ->
   Alcotest.speed_level ->
   ('a -> unit Async_kernel.Deferred.t) ->
-  'a Alcotest.test_case
+  'a test_case
+
+val test_case' : string -> Alcotest.speed_level -> ('a -> unit) -> 'a test_case

--- a/async/alcotest_async.mli
+++ b/async/alcotest_async.mli
@@ -17,7 +17,7 @@
 (** [Alcotest_async] enables testing functions which return an Async deferred.
     {!run} returns a deferred which will run the tests when scheduled. *)
 
-include Alcotest.TESTER with type return = unit Async_kernel.Deferred.t
+include Alcotest.S with type return = unit Async_kernel.Deferred.t
 
 val test_case :
   ?timeout:Core_kernel.Time.Span.t ->

--- a/examples/lwt/test.ml
+++ b/examples/lwt/test.ml
@@ -85,19 +85,20 @@ let test_switch_dealloc _ () =
 
 (* Run it *)
 let () =
-  Alcotest.run "LwtUtils"
-    [ ( "basic",
-        [ Alcotest.test_case "Plain" `Quick test_lowercase;
-          Alcotest_lwt.test_case "Lwt" `Quick test_lowercase_lwt
-        ] );
-      ( "exceptions",
-        [ Alcotest.test_case "Plain" `Quick test_exn;
-          Alcotest_lwt.test_case "Lwt toplevel" `Quick test_exn_lwt_toplevel;
-          Alcotest_lwt.test_case "Lwt internal" `Quick test_exn_lwt_internal
-        ] );
-      ( "switches",
-        [ Alcotest_lwt.test_case "Allocate resource" `Quick test_switch_alloc;
-          Alcotest_lwt.test_case "Check resource is deallocated" `Quick
-            test_switch_dealloc
-        ] )
-    ]
+  let open Alcotest_lwt in
+  Lwt_main.run
+  @@ run "LwtUtils"
+       [ ( "basic",
+           [ test_case' "Plain" `Quick test_lowercase;
+             test_case "Lwt" `Quick test_lowercase_lwt
+           ] );
+         ( "exceptions",
+           [ test_case' "Plain" `Quick test_exn;
+             test_case "Lwt toplevel" `Quick test_exn_lwt_toplevel;
+             test_case "Lwt internal" `Quick test_exn_lwt_internal
+           ] );
+         ( "switches",
+           [ test_case "Allocate resource" `Quick test_switch_alloc;
+             test_case "Check resource deallocated" `Quick test_switch_dealloc
+           ] )
+       ]

--- a/lwt/alcotest_lwt.ml
+++ b/lwt/alcotest_lwt.ml
@@ -14,14 +14,18 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let run fn args =
+module Tester = Alcotest.MonadicTester (Lwt)
+include Tester
+
+let test_case' n s f = test_case n s (fun x -> Lwt.return (f x))
+
+let run_test fn args =
   let async_ex, async_waker = Lwt.wait () in
   let handle_exn ex =
     Logs.debug (fun f -> f "Uncaught async exception: %a" Fmt.exn ex);
     if Lwt.state async_ex = Lwt.Sleep then Lwt.wakeup_exn async_waker ex
   in
   Lwt.async_exception_hook := handle_exn;
-  Lwt_main.run
-  @@ Lwt_switch.with_switch (fun sw -> Lwt.pick [ fn sw args; async_ex ])
+  Lwt_switch.with_switch (fun sw -> Lwt.pick [ fn sw args; async_ex ])
 
-let test_case n s f = Alcotest.test_case n s (run f)
+let test_case n s f = test_case n s (run_test f)

--- a/lwt/alcotest_lwt.ml
+++ b/lwt/alcotest_lwt.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Tester = Alcotest.MonadicTester (Lwt)
+module Tester = Alcotest.Make (Lwt)
 include Tester
 
 let test_case' n s f = test_case n s (fun x -> Lwt.return (f x))

--- a/lwt/alcotest_lwt.mli
+++ b/lwt/alcotest_lwt.mli
@@ -18,7 +18,7 @@
     {!run} returns a promise that runs the tests when scheduled, catching
     any asynchronous exceptions thrown by the tests. *)
 
-include Alcotest.TESTER with type return = unit Lwt.t
+include Alcotest.S with type return = unit Lwt.t
 
 val test_case :
   string ->

--- a/lwt/alcotest_lwt.mli
+++ b/lwt/alcotest_lwt.mli
@@ -14,12 +14,16 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-(** [Alcotest_lwt] allows to defines tests which returns an Lwt
-    promise. {!run} will run these promises and will catch asynchrous
-    exceptions. *)
+(** [Alcotest_lwt] enables testing functions which return an Lwt promise.
+    {!run} returns a promise that runs the tests when scheduled, catching
+    any asynchronous exceptions thrown by the tests. *)
+
+include Alcotest.TESTER with type return = unit Lwt.t
 
 val test_case :
   string ->
   Alcotest.speed_level ->
   (Lwt_switch.t -> 'a -> unit Lwt.t) ->
-  'a Alcotest.test_case
+  'a test_case
+
+val test_case' : string -> Alcotest.speed_level -> ('a -> unit) -> 'a test_case

--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -61,7 +61,7 @@ exception Test_error
 
 type speed_level = [ `Quick | `Slow ]
 
-module type TESTER = sig
+module type S = sig
   type return
 
   type 'a test_case = string * speed_level * ('a -> return)
@@ -82,7 +82,7 @@ module type TESTER = sig
     return
 end
 
-module MonadicTester (M : MONAD) = struct
+module Make (M : MONAD) = struct
 module M = ExtendMonad (M)
 include M.Infix
 
@@ -738,7 +738,7 @@ module IdentityMonad = struct
   let bind x f = f x
 end
 
-module T = MonadicTester (IdentityMonad)
+module T = Make (IdentityMonad)
 include T
 
 module type TESTABLE = sig

--- a/src/alcotest.mli
+++ b/src/alcotest.mli
@@ -36,7 +36,7 @@ type speed_level = [ `Quick | `Slow ]
 (** Speed level of a test. Tests marked as [`Quick] are always run. Tests marked
     as [`Slow] are skipped when the `-q` flag is passed. *)
 
-module type TESTER = sig
+module type S = sig
   type return
 
 type 'a test_case = string * speed_level * ('a -> return)
@@ -84,7 +84,7 @@ val run_with_args :
     the test behaviors using the CLI. *)
 end
 
-include TESTER with type return = unit
+include S with type return = unit
 
 module type MONAD = sig
   type 'a t
@@ -94,7 +94,7 @@ module type MONAD = sig
   val bind : 'a t -> ('a -> 'b t) -> 'b t
 end
 
-module MonadicTester (M : MONAD) : TESTER with type return = unit M.t
+module Make (M : MONAD) : S with type return = unit M.t
 (** Functor for building a tester that sequences tests of type [('a -> unit M.t)]
     within a given concurrency monad [M.t]. The [run] and [run_with_args] functions
     must be scheduled in a global event loop. Intended for use by the {!Alcotest_lwt}


### PR DESCRIPTION
This resolves #119 by parameterising the core testing logic on a concurrency monad. This allows `Alcotest_lwt` and `Alcotest_async` to provide `run` methods that return promises, rather than using `Lwt_main.run` and `Thread_safe.block_on_async_exn` internally. As discussed in #119, these scheduling methods present problems for Javascript/Mirage deployments.

This PR is currently not `ocamlformat`-ted to minimise the diff while it's under review.

### API changes
- Standard `Alcotest` keeps the same API, with no changes.

- `Alcotest.run` can now no longer run `Alcotest_lwt` test cases, which must instead be passed to `Alcotest_lwt.run` (see [this diff](https://github.com/mirage/alcotest/compare/master...CraigFe:monad#diff-0f4ab61e93c78dfaac56b35c0c0ed0f5)). The asynchronous backends now provide an unimaginatively named `test_case'` fallback for running synchronous tests (avoiding the user boilerplate of lifting these tests inside the monad). Is there a better name for this method?


