### PR TITLE
Add CI runners for OS X and Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
-script: bash -ex .travis-docker.sh
-services:
-  - docker
-sudo: false
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
 env:
- global:
-   - PINS="alcotest:. alcotest-lwt:. alcotest-async:."
- matrix:
-   - DISTRO=alpine          OCAML_VERSION=4.04 PACKAGE="alcotest-lwt"
-   - DISTRO=debian-stable   OCAML_VERSION=4.05 PACKAGE="alcotest-async"
-   - DISTRO=debian-testing  OCAML_VERSION=4.06 PACKAGE="alcotest"
-   - DISTRO=fedora          OCAML_VERSION=4.07 PACKAGE="alcotest"
+  global:
+    - PINS="alcotest:. alcotest-lwt:. alcotest-async:."
+matrix:
+  include:
+    - os: linux
+      env: OCAML_VERSION=4.04 PACKAGE="alcotest-lwt"
+    - os: linux
+      env: OCAML_VERSION=4.05 PACKAGE="alcotest-async"
+    - os: linux
+      env: OCAML_VERSION=4.06 PACKAGE="alcotest"
+    - os: linux
+      env: OCAML_VERSION=4.07 PACKAGE="alcotest"
+    - os: osx
+      env: OCAML_VERSION=4.07 PACKAGE="alcotest"
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+platform:
+  - x86
+
+environment:
+  global:
+    FORK_USER: ocaml
+    FORK_BRANCH: master
+    CYG_ROOT: C:\cygwin64
+    OPAM_SWITCH: 4.06.1+mingw64c
+    PINS: "alcotest.dev:."
+  matrix:
+    - PACKAGE: "alcotest.dev"
+
+install:
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))
+
+build_script:
+  - call %CYG_ROOT%\bin\bash.exe -l %APPVEYOR_BUILD_FOLDER%\appveyor-opam.sh


### PR DESCRIPTION
It would be nice to have CI on multiple OSs, since we currently use the file system to store log outputs of tests.

Currently just experimenting with TravisCI multi-OS support; not intended for merging.