### PR TITLE
Initial end-to-end test suite

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.1)
+(lang dune 1.11)
 (name alcotest)
 (using fmt 1.0)

--- a/test/e2e/dune
+++ b/test/e2e/dune
@@ -1,0 +1,18 @@
+(executable
+ (name gen_dune_rules)
+ (libraries cmdliner fmt)
+ (modules gen_dune_rules)
+)
+
+(executable
+ (name expect_failure)
+ (libraries unix fmt)
+ (modules expect_failure)
+)
+
+(executable
+ (name strip_randomness)
+ (libraries unix re)
+ (modules strip_randomness)
+)
+

--- a/test/e2e/expect_failure.ml
+++ b/test/e2e/expect_failure.ml
@@ -1,0 +1,9 @@
+(* Run an executable and negate its return status *)
+let () =
+  let args = List.tl (Array.to_list Sys.argv) in
+  let command = Fmt.strf "%a" Fmt.(list ~sep:(const string " ") string) args in
+  let rel_command = Filename.(concat current_dir_name) command in
+  match Unix.system rel_command with
+  | WEXITED 0 -> exit 1
+  | WEXITED _ -> exit 0
+  | WSIGNALED _ | WSTOPPED _ -> failwith "Process terminated by a signal"

--- a/test/e2e/failing/dune
+++ b/test/e2e/failing/dune
@@ -1,0 +1,17 @@
+(include dune.inc)
+
+(rule
+ (targets dune.gen)
+ (deps (source_tree .))
+ (action
+  (with-stdout-to
+    %{targets}
+   (run ../gen_dune_rules.exe --expect-failure)
+  )
+ )
+)
+
+(alias
+ (name runtest)
+ (action (diff dune.inc dune.gen))
+)

--- a/test/e2e/failing/dune.inc
+++ b/test/e2e/failing/dune.inc
@@ -1,0 +1,35 @@
+(executables
+ (names
+   unicode_testname
+ )
+ (libraries alcotest)
+ (modules
+   unicode_testname
+ )
+)
+
+(rule
+ (target unicode_testname.actual)
+ (action
+  (with-outputs-to %{target}
+   (run ../expect_failure.exe %{dep:unicode_testname.exe})
+  )
+ )
+)
+
+(rule
+ (target unicode_testname.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:unicode_testname.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff unicode_testname.expected unicode_testname.processed)
+ )
+)

--- a/test/e2e/failing/unicode_testname.expected
+++ b/test/e2e/failing/unicode_testname.expected
@@ -1,0 +1,1 @@
+Error: "\240\159\148\165" is not a valid test label (must match ^[a-zA-Z0-9_- ]+$).

--- a/test/e2e/failing/unicode_testname.ml
+++ b/test/e2e/failing/unicode_testname.ml
@@ -1,0 +1,3 @@
+let () =
+  Alcotest.run "suite-name"
+    [ ("🔥", [ Alcotest.test_case "First test case" `Quick (fun () -> ()) ]) ]

--- a/test/e2e/gen_dune_rules.ml
+++ b/test/e2e/gen_dune_rules.ml
@@ -1,0 +1,87 @@
+let global_stanza filenames =
+  let bases = List.map Filename.remove_extension filenames in
+  let pp_sexp_list = Fmt.(list ~sep:(const string "\n   ")) in
+  Fmt.pr
+    {|(executables
+ (names
+   %a
+ )
+ (libraries alcotest)
+ (modules
+   %a
+ )
+)
+|}
+    (pp_sexp_list Fmt.string) bases (pp_sexp_list Fmt.string) bases
+
+let example_rule_stanza ~expect_failure filename =
+  let base = Filename.remove_extension filename in
+  let expect_failure =
+    if expect_failure then "../expect_failure.exe " else ""
+  in
+  (* Run Alcotest to get *.actual, then pass through the strip_randomness
+     sanitiser to get *.processed. *)
+  Fmt.pr
+    {|
+(rule
+ (target %s.actual)
+ (action
+  (with-outputs-to %%{target}
+   (run %s%%{dep:%s.exe})
+  )
+ )
+)
+
+(rule
+ (target %s.processed)
+ (action
+  (with-outputs-to %%{target}
+   (run ../strip_randomness.exe %%{dep:%s.actual})
+  )
+ )
+)
+
+|}
+    base expect_failure base base base
+
+let example_alias_stanza filename =
+  let base = Filename.remove_extension filename in
+  Fmt.pr
+    {|
+(alias
+ (name runtest)
+ (action
+   (diff %s.expected %s.processed)
+ )
+)
+|}
+    base base
+
+let is_example filename = Filename.check_suffix filename ".ml"
+
+let main expect_failure =
+  Sys.readdir "." |> Array.to_list |> List.sort String.compare
+  |> List.filter is_example
+  |> function
+  | [] -> () (* no tests to execute *)
+  | tests ->
+      global_stanza tests;
+      List.iter
+        (fun test ->
+          example_rule_stanza ~expect_failure test;
+          example_alias_stanza test)
+        tests
+
+open Cmdliner
+
+let expect_failure =
+  let doc =
+    Arg.info ~doc:"Negate the return status of the tests" [ "expect-failure" ]
+  in
+  Arg.(value & flag doc)
+
+let term =
+  Term.
+    (const main $ expect_failure, info ~version:"%%VERSION%%" "gen_dune_rules")
+
+let () = Term.(exit @@ eval term)

--- a/test/e2e/passing/basic.expected
+++ b/test/e2e/passing/basic.expected
@@ -1,0 +1,8 @@
+Testing suite-name.
+This run has ID `<uuid>`.
+ ...                test-a          0   First test case.[OK]                test-a          0   First test case.
+ ...                test-a          1   Second test case.[OK]                test-a          1   Second test case.
+ ...                test-b          0   Third test case.[OK]                test-b          0   Third test case.
+ ...                test-c          0   Fourth test case.[OK]                test-c          0   Fourth test case.
+The full test results are available in `<build-context>/_build/_tests/<uuid>`.
+Test Successful in <test-duration>s. 4 tests run.

--- a/test/e2e/passing/basic.ml
+++ b/test/e2e/passing/basic.ml
@@ -1,0 +1,11 @@
+let () =
+  let open Alcotest in
+  let id () = () in
+  run "suite-name"
+    [ ( "test-a",
+        [ test_case "First test case" `Quick id;
+          test_case "Second test case" `Quick id
+        ] );
+      ("test-b", [ test_case "Third test case" `Quick id ]);
+      ("test-c", [ test_case "Fourth test case" `Slow id ])
+    ]

--- a/test/e2e/passing/dune
+++ b/test/e2e/passing/dune
@@ -1,0 +1,17 @@
+(include dune.inc)
+
+(rule
+ (targets dune.gen)
+ (deps (source_tree .))
+ (action
+  (with-stdout-to
+    %{targets}
+   (run ../gen_dune_rules.exe)
+  )
+ )
+)
+
+(alias
+ (name runtest)
+ (action (diff dune.inc dune.gen))
+)

--- a/test/e2e/passing/dune.inc
+++ b/test/e2e/passing/dune.inc
@@ -1,0 +1,35 @@
+(executables
+ (names
+   basic
+ )
+ (libraries alcotest)
+ (modules
+   basic
+ )
+)
+
+(rule
+ (target basic.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:basic.exe})
+  )
+ )
+)
+
+(rule
+ (target basic.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:basic.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff basic.expected basic.processed)
+ )
+)

--- a/test/e2e/strip_randomness.ml
+++ b/test/e2e/strip_randomness.ml
@@ -1,0 +1,52 @@
+let standardise_filesep =
+  let re = Re.compile (Re.str Filename.dir_sep) in
+  Re.replace_string ~all:true re ~by:"/"
+
+let build_context_replace =
+  let open Re in
+  let t = seq [ char '`'; rep any; str "_build"; group (rep any); char '`' ] in
+  let re = compile t in
+  replace ~all:true re ~f:(fun g ->
+      let test_dir = standardise_filesep (Group.get g 1) in
+      "`<build-context>/_build" ^ test_dir ^ "`")
+
+let uuid_replace =
+  let open Re in
+  let hex n = repn (alt [ rg 'A' 'F'; digit ]) n (Some n) in
+  let segmented_hex ns =
+    let segments = List.map (fun n -> [ char '-'; hex n ]) ns in
+    List.flatten segments |> List.tl |> seq
+  in
+  let t = segmented_hex [ 8; 4; 4; 4; 12 ] in
+  let re = compile t in
+  replace_string ~all:true re ~by:"<uuid>"
+
+let time_replace =
+  let open Re in
+  let t =
+    seq
+      [ str "Test Successful in ";
+        rep1 Re.digit;
+        char '.';
+        rep1 Re.digit;
+        char 's'
+      ]
+  in
+  let re = compile t in
+  replace_string ~all:true re ~by:"Test Successful in <test-duration>s"
+
+(* Remove all non-deterministic output in a given Alcotest log and write
+   the result to std.out *)
+let () =
+  let in_channel = open_in Sys.argv.(1) in
+  try
+    let rec loop () =
+      let sanitized_line =
+        input_line in_channel |> uuid_replace |> build_context_replace
+        |> time_replace
+      in
+      Printf.printf "%s\n" sanitized_line;
+      loop ()
+    in
+    loop ()
+  with End_of_file -> close_in in_channel


### PR DESCRIPTION
This initialises an end-to-end test suite that compares example executions against expected outputs. The process is driven by auto-generated `dune` files, allowing a workflow of `dune runtest` →  `dune promote`. 

Currently this does not allow for passing options to the executable under test, which would be a nice addition. For this, we could use extra `*.opt` files similarly to [how it's being done in OCamlformat](https://github.com/ocaml-ppx/ocamlformat/tree/master/test/passing). 

### Frustrations
1. The `dune` action DSL has no way of negating the exit code of a command, so it's being done manually with a little script -- I might request this as a Dune feature...

1. It's necessary to sanitize the output of the tests to remove environment dependencies / randomness. Again, this is being done by an extra script.

1. I initially added symlinks to the `examples/` directory to verify their output, but these appear to break the Windows CI, so I removed them.