### PR TITLE
Add tests of CLI args and testables

### DIFF
--- a/src/alcotest.ml
+++ b/src/alcotest.ml
@@ -352,7 +352,7 @@ module Make (M : MONAD) = struct
             let file = open_in filename in
             let output = string_of_channel file in
             close_in file;
-            Fmt.strf "in %s:\n%s" filename output
+            Fmt.strf "in `%s`:\n%s" filename output
         in
         let error =
           Fmt.strf "-- %s [%s] Failed --\n%s"

--- a/test/e2e/failing/dune.inc
+++ b/test/e2e/failing/dune.inc
@@ -1,10 +1,38 @@
 (executables
  (names
+   exception_in_test
    unicode_testname
  )
  (libraries alcotest)
  (modules
+   exception_in_test
    unicode_testname
+ )
+)
+
+(rule
+ (target exception_in_test.actual)
+ (action
+  (with-outputs-to %{target}
+   (run ../expect_failure.exe %{dep:exception_in_test.exe})
+  )
+ )
+)
+
+(rule
+ (target exception_in_test.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:exception_in_test.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff exception_in_test.expected exception_in_test.processed)
  )
 )
 

--- a/test/e2e/failing/exception_in_test.expected
+++ b/test/e2e/failing/exception_in_test.expected
@@ -1,0 +1,11 @@
+Testing suite-with-failures.
+This run has ID `<uuid>`.
+ ...                test-a          0   Passing.[OK]                test-a          0   Passing.
+ ...                test-a          1   Failing.[FAIL]              test-a          1   Failing.
+ ...                test-b          0   Another pass.[OK]                test-b          0   Another pass.
+-- test-a.001 [Failing.] Failed --
+in `<build-context>/_build/_tests/<uuid>/test-a.001.output`:
+[invalid] Failing test
+
+The full test results are available in `<build-context>/_build/_tests/<uuid>`.
+1 error! in 0.000s. 3 tests run.

--- a/test/e2e/failing/exception_in_test.ml
+++ b/test/e2e/failing/exception_in_test.ml
@@ -1,0 +1,9 @@
+let () =
+  let open Alcotest in
+  run "suite-with-failures"
+    [ ( "test-a",
+        [ test_case "Passing" `Quick (fun () -> ());
+          test_case "Failing" `Quick (fun () -> invalid_arg "Failing test")
+        ] );
+      ("test-b", [ test_case "Another pass" `Quick (fun () -> ()) ])
+    ]

--- a/test/e2e/passing/and_exit_false.expected
+++ b/test/e2e/passing/and_exit_false.expected
@@ -1,0 +1,7 @@
+Testing suite-name.
+This run has ID `<uuid>`.
+ ...                test-a          0   Test case.[OK]                test-a          0   Test case.
+The full test results are available in `<build-context>/_build/_tests/<uuid>`.
+Test Successful in <test-duration>s. 1 test run.
+
+ Program execution continued!

--- a/test/e2e/passing/and_exit_false.ml
+++ b/test/e2e/passing/and_exit_false.ml
@@ -1,0 +1,6 @@
+let () =
+  let open Alcotest in
+  let id () = () in
+  run ~and_exit:false "suite-name"
+    [ ("test-a", [ test_case "Test case" `Quick id ]) ];
+  Printf.printf "\n Program execution continued!%!"

--- a/test/e2e/passing/and_exit_true.expected
+++ b/test/e2e/passing/and_exit_true.expected
@@ -1,0 +1,5 @@
+Testing suite-name.
+This run has ID `<uuid>`.
+ ...                test-a          0   Test case.[OK]                test-a          0   Test case.
+The full test results are available in `<build-context>/_build/_tests/<uuid>`.
+Test Successful in <test-duration>s. 1 test run.

--- a/test/e2e/passing/and_exit_true.ml
+++ b/test/e2e/passing/and_exit_true.ml
@@ -1,0 +1,7 @@
+let () =
+  let open Alcotest in
+  let id () = () in
+  run ~and_exit:true "suite-name"
+    [ ("test-a", [ test_case "Test case" `Quick id ]) ];
+  Printf.printf "\n Should never be printed!%!";
+  assert false

--- a/test/e2e/passing/check_basic.expected
+++ b/test/e2e/passing/check_basic.expected
@@ -1,0 +1,25 @@
+Testing passing testables.
+This run has ID `<uuid>`.
+ ...                reflexive basic              0   unit.[OK]                reflexive basic              0   unit.
+ ...                reflexive basic              1   bool.[OK]                reflexive basic              1   bool.
+ ...                reflexive basic              2   int.[OK]                reflexive basic              2   int.
+ ...                reflexive basic              3   int32.[OK]                reflexive basic              3   int32.
+ ...                reflexive basic              4   int64.[OK]                reflexive basic              4   int64.
+ ...                reflexive basic              5   float.[OK]                reflexive basic              5   float.
+ ...                reflexive basic              6   char.[OK]                reflexive basic              6   char.
+ ...                reflexive basic              7   string.[OK]                reflexive basic              7   string.
+ ...                reflexive composite          0   empty list.[OK]                reflexive composite          0   empty list.
+ ...                reflexive composite          1   non-empty list.[OK]                reflexive composite          1   non-empty list.
+ ...                reflexive composite          2   empty array.[OK]                reflexive composite          2   empty array.
+ ...                reflexive composite          3   non-empty array.[OK]                reflexive composite          3   non-empty array.
+ ...                reflexive composite          4   option some.[OK]                reflexive composite          4   option some.
+ ...                reflexive composite          5   option none.[OK]                reflexive composite          5   option none.
+ ...                reflexive composite          6   result ok.[OK]                reflexive composite          6   result ok.
+ ...                reflexive composite          7   result error.[OK]                reflexive composite          7   result error.
+ ...                reflexive composite          8   pair.[OK]                reflexive composite          8   pair.
+ ...                negation                     0   checked exceptions.[OK]                negation                     0   checked exceptions.
+ ...                negation                     1   negated testables.[OK]                negation                     1   negated testables.
+ ...                fuzzy equality               0   float thresholds.[OK]                fuzzy equality               0   float thresholds.
+ ...                fuzzy equality               1   sorted list.[OK]                fuzzy equality               1   sorted list.
+The full test results are available in `<build-context>/_build/_tests/<uuid>`.
+Test Successful in <test-duration>s. 21 tests run.

--- a/test/e2e/passing/check_basic.ml
+++ b/test/e2e/passing/check_basic.ml
@@ -1,0 +1,69 @@
+(* Check that v of type [typ] matches with itself *)
+let id_case typ typ_str v =
+  Alcotest.test_case typ_str `Quick (fun () -> Alcotest.check typ typ_str v v)
+
+let make_checks () =
+  let open Alcotest in
+  check unit "unit" () ();
+  check bool "bool" true true;
+  check int "int " 0 0;
+  check int32
+
+let checked_exceptions () =
+  let check_refl name exn =
+    Alcotest.check_raises name exn (fun () -> raise exn)
+  in
+  let exception Zero in
+  let exception One of int in
+  let exception Two of int * char in
+  check_refl "0-tuple" Zero;
+  check_refl "1-tuple" (One 1);
+  check_refl "2-tuple" (Two (1, 'a'))
+
+let negated_testables () =
+  Alcotest.(check (neg reject)) "!reject" () ();
+  Alcotest.(check (neg @@ neg pass)) "!!pass" () ();
+  Alcotest.(check (neg @@ neg @@ neg reject)) "!!!reject" () ();
+  Alcotest.(check (neg char)) "!different" 'a' 'b'
+
+let float_threshold () =
+  Alcotest.(check (float 1.0) "within threshold") 0.1 0.2;
+  Alcotest.(check (neg (float 0.01)) "not within threshold") 0.1 0.2
+
+let sorted_list () =
+  let int_compare : int -> int -> int = compare in
+  Alcotest.(check (slist int int_compare)) "sorted" [ 1; 2; 3 ] [ 3; 2; 1 ]
+
+let () =
+  let open Alcotest in
+  run "passing testables"
+    [ ( "reflexive basic",
+        [ id_case unit "unit" ();
+          id_case bool "bool" true;
+          id_case int "int" 1;
+          id_case int32 "int32" Int32.max_int;
+          id_case int64 "int64" Int64.max_int;
+          id_case (float 0.0) "float" 1.0;
+          id_case char "char" 'a';
+          id_case string "string" "Lorem ipsum dolor sit amet."
+        ] );
+      ( "reflexive composite",
+        [ id_case (list int) "empty list" [];
+          id_case (list char) "non-empty list" [ 'a'; 'b'; 'c' ];
+          id_case (array unit) "empty array" [||];
+          id_case (array int64) "non-empty array" Int64.[| zero; max_int |];
+          id_case (option int) "option some" (Some 1);
+          id_case (option int) "option none" None;
+          id_case (result int unit) "result ok" (Ok 1);
+          id_case (result int unit) "result error" (Error ());
+          id_case (pair int char) "pair" (1, 'a')
+        ] );
+      ( "negation",
+        [ test_case "checked exceptions" `Quick checked_exceptions;
+          test_case "negated testables" `Quick negated_testables
+        ] );
+      ( "fuzzy equality",
+        [ test_case "float thresholds" `Quick float_threshold;
+          test_case "sorted list" `Quick sorted_list
+        ] )
+    ]

--- a/test/e2e/passing/dune.inc
+++ b/test/e2e/passing/dune.inc
@@ -1,10 +1,80 @@
 (executables
  (names
+   and_exit_false
+   and_exit_true
    basic
+   check_basic
+   filter_name
+   filter_name_regex
+   json_output
+   list_tests
+   quick_only
+   quick_only_regex
  )
  (libraries alcotest)
  (modules
+   and_exit_false
+   and_exit_true
    basic
+   check_basic
+   filter_name
+   filter_name_regex
+   json_output
+   list_tests
+   quick_only
+   quick_only_regex
+ )
+)
+
+(rule
+ (target and_exit_false.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:and_exit_false.exe})
+  )
+ )
+)
+
+(rule
+ (target and_exit_false.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:and_exit_false.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff and_exit_false.expected and_exit_false.processed)
+ )
+)
+
+(rule
+ (target and_exit_true.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:and_exit_true.exe})
+  )
+ )
+)
+
+(rule
+ (target and_exit_true.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:and_exit_true.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff and_exit_true.expected and_exit_true.processed)
  )
 )
 
@@ -31,5 +101,187 @@
  (name runtest)
  (action
    (diff basic.expected basic.processed)
+ )
+)
+
+(rule
+ (target check_basic.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:check_basic.exe})
+  )
+ )
+)
+
+(rule
+ (target check_basic.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:check_basic.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff check_basic.expected check_basic.processed)
+ )
+)
+
+(rule
+ (target filter_name.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:filter_name.exe})
+  )
+ )
+)
+
+(rule
+ (target filter_name.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:filter_name.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff filter_name.expected filter_name.processed)
+ )
+)
+
+(rule
+ (target filter_name_regex.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:filter_name_regex.exe})
+  )
+ )
+)
+
+(rule
+ (target filter_name_regex.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:filter_name_regex.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff filter_name_regex.expected filter_name_regex.processed)
+ )
+)
+
+(rule
+ (target json_output.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:json_output.exe})
+  )
+ )
+)
+
+(rule
+ (target json_output.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:json_output.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff json_output.expected json_output.processed)
+ )
+)
+
+(rule
+ (target list_tests.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:list_tests.exe})
+  )
+ )
+)
+
+(rule
+ (target list_tests.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:list_tests.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff list_tests.expected list_tests.processed)
+ )
+)
+
+(rule
+ (target quick_only.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:quick_only.exe})
+  )
+ )
+)
+
+(rule
+ (target quick_only.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:quick_only.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff quick_only.expected quick_only.processed)
+ )
+)
+
+(rule
+ (target quick_only_regex.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:quick_only_regex.exe})
+  )
+ )
+)
+
+(rule
+ (target quick_only_regex.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:quick_only_regex.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff quick_only_regex.expected quick_only_regex.processed)
  )
 )

--- a/test/e2e/passing/filter_name.expected
+++ b/test/e2e/passing/filter_name.expected
@@ -1,0 +1,7 @@
+Testing suite-name.
+This run has ID `<uuid>`.
+ ...                test-a          0   First test case.[OK]                test-a          0   First test case.
+ ...                test-a          1   Second test case.[OK]                test-a          1   Second test case.
+ ...                test-b          0   Skipped failing test.[SKIP]              test-b          0   Skipped failing test.
+The full test results are available in `<build-context>/_build/_tests/<uuid>`.
+Test Successful in <test-duration>s. 2 tests run.

--- a/test/e2e/passing/filter_name.ml
+++ b/test/e2e/passing/filter_name.ml
@@ -1,0 +1,13 @@
+let () =
+  let open Alcotest in
+  let id () = () in
+  run ~argv:[| ""; "test"; "test-a" |] "suite-name"
+    [ ( "test-a",
+        [ test_case "First test case" `Quick id;
+          test_case "Second test case" `Quick id
+        ] );
+      ( "test-b",
+        [ test_case "Skipped failing test" `Quick (fun () ->
+              invalid_arg "boom")
+        ] )
+    ]

--- a/test/e2e/passing/filter_name_regex.expected
+++ b/test/e2e/passing/filter_name_regex.expected
@@ -1,0 +1,9 @@
+Testing suite-name.
+This run has ID `<uuid>`.
+ ...                basic-run-a            0   Executed.[OK]                basic-run-a            0   Executed.
+ ...                basic-run-a            1   Also executed.[OK]                basic-run-a            1   Also executed.
+ ...                basic-run-b            0   Skipped.[SKIP]              basic-run-b            0   Skipped.
+ ...                basic-run-c            0   Executed.[OK]                basic-run-c            0   Executed.
+ ...                complex-run-a          0   Skipped.[SKIP]              complex-run-a          0   Skipped.
+The full test results are available in `<build-context>/_build/_tests/<uuid>`.
+Test Successful in <test-duration>s. 3 tests run.

--- a/test/e2e/passing/filter_name_regex.ml
+++ b/test/e2e/passing/filter_name_regex.ml
@@ -1,0 +1,13 @@
+let () =
+  let open Alcotest in
+  let id () = () in
+  run
+    ~argv:[| ""; "test"; "basic-.*-(a|c)" |]
+    "suite-name"
+    [ ( "basic-run-a",
+        [ test_case "Executed" `Quick id; test_case "Also executed" `Quick id ]
+      );
+      ("basic-run-b", [ test_case "Skipped" `Quick id ]);
+      ("basic-run-c", [ test_case "Executed" `Quick id ]);
+      ("complex-run-a", [ test_case "Skipped" `Quick id ])
+    ]

--- a/test/e2e/passing/json_output.expected
+++ b/test/e2e/passing/json_output.expected
@@ -1,0 +1,3 @@
+{"success":3,"failures":0,"time":0.000000}
+Testing suite-name.
+This run has ID `<uuid>`.

--- a/test/e2e/passing/json_output.ml
+++ b/test/e2e/passing/json_output.ml
@@ -1,0 +1,10 @@
+let () =
+  let open Alcotest in
+  let id () = () in
+  run ~argv:[| ""; "--json" |] "suite-name"
+    [ ( "test-a",
+        [ test_case "First test case" `Quick id;
+          test_case "Second test case" `Quick id
+        ] );
+      ("test-b", [ test_case "Third test case" `Quick id ])
+    ]

--- a/test/e2e/passing/list_tests.expected
+++ b/test/e2e/passing/list_tests.expected
@@ -1,0 +1,5 @@
+Testing suite-name.
+This run has ID `<uuid>`.
+test-a          0    alpha.
+test-a          1    beta.
+test-b          0    lorem ipsum dolor sit amet consectutor adipiscing elit.

--- a/test/e2e/passing/list_tests.ml
+++ b/test/e2e/passing/list_tests.ml
@@ -1,0 +1,12 @@
+let () =
+  let open Alcotest in
+  let failtest () = invalid_arg "This test should never be run" in
+  run ~argv:[| ""; "list" |] "suite-name"
+    [ ( "test-a",
+        [ test_case "alpha" `Quick failtest; test_case "beta" `Quick failtest ]
+      );
+      ( "test-b",
+        [ test_case "lorem ipsum dolor sit amet consectutor adipiscing elit"
+            `Quick failtest
+        ] )
+    ]

--- a/test/e2e/passing/quick_only.expected
+++ b/test/e2e/passing/quick_only.expected
@@ -1,0 +1,8 @@
+Testing suite-name.
+This run has ID `<uuid>`.
+ ...                test-a          0   Quick.[OK]                test-a          0   Quick.
+ ...                test-a          1   Slow.[SKIP]              test-a          1   Slow.
+ ...                test-b          0   Slow.[SKIP]              test-b          0   Slow.
+ ...                test-b          1   Quick.[OK]                test-b          1   Quick.
+The full test results are available in `<build-context>/_build/_tests/<uuid>`.
+Test Successful in <test-duration>s. 2 tests run.

--- a/test/e2e/passing/quick_only.ml
+++ b/test/e2e/passing/quick_only.ml
@@ -1,0 +1,7 @@
+let () =
+  let open Alcotest in
+  let id () = () in
+  run ~argv:[| ""; "--quick" |] "suite-name"
+    [ ("test-a", [ test_case "Quick" `Quick id; test_case "Slow" `Slow id ]);
+      ("test-b", [ test_case "Slow" `Slow id; test_case "Quick" `Quick id ])
+    ]

--- a/test/e2e/passing/quick_only_regex.expected
+++ b/test/e2e/passing/quick_only_regex.expected
@@ -1,0 +1,8 @@
+Testing suite-name.
+This run has ID `<uuid>`.
+ ...                test-a          0   Quick & passes filter.[OK]                test-a          0   Quick & passes filter.
+ ...                test-a          1   Slow & passes filter.[SKIP]              test-a          1   Slow & passes filter.
+ ...                test-b          0   Slow & fails filter.[SKIP]              test-b          0   Slow & fails filter.
+ ...                test-b          1   Quick & fails filter.[SKIP]              test-b          1   Quick & fails filter.
+The full test results are available in `<build-context>/_build/_tests/<uuid>`.
+Test Successful in <test-duration>s. 1 test run.

--- a/test/e2e/passing/quick_only_regex.ml
+++ b/test/e2e/passing/quick_only_regex.ml
@@ -1,0 +1,15 @@
+let () =
+  let open Alcotest in
+  let id () = () in
+  run
+    ~argv:[| ""; "test"; "--quick"; ".*-a" |]
+    "suite-name"
+    [ ( "test-a",
+        [ test_case "Quick & passes filter" `Quick id;
+          test_case "Slow & passes filter" `Slow id
+        ] );
+      ( "test-b",
+        [ test_case "Slow & fails filter" `Slow id;
+          test_case "Quick & fails filter" `Quick id
+        ] )
+    ]


### PR DESCRIPTION
Adds a load of additional end-to-end tests intended to verify the behavior of the command-line arguments (and the `testable` checks). This will ease future restructuring of the Cmdliner logic.