### PR TITLE
Remove stray Alcotest_cli dune file

### DIFF
--- a/src/cli/dune
+++ b/src/cli/dune
@@ -1,4 +1,0 @@
-(library
- (public_name alcotest.cli)
- (name alcotest_cli)
- (libraries alcotest cmdliner fmt.cli))


### PR DESCRIPTION
Should have been deleted as part of commit
6c6a23a56bf953166435418e644aef1422e4e876.