### PR TITLE
expose Alcotest.speed_level again (instead of Alcotest.Core.speed_level)

### DIFF
--- a/async/alcotest_async.mli
+++ b/async/alcotest_async.mli
@@ -22,9 +22,9 @@ include Alcotest.Core.S with type return = unit Async_kernel.Deferred.t
 val test_case :
   ?timeout:Core_kernel.Time.Span.t ->
   string ->
-  Alcotest.Core.speed_level ->
+  Alcotest.speed_level ->
   ('a -> unit Async_kernel.Deferred.t) ->
   'a test_case
 
 val test_case' :
-  string -> Alcotest.Core.speed_level -> ('a -> unit) -> 'a test_case
+  string -> Alcotest.speed_level -> ('a -> unit) -> 'a test_case

--- a/lwt/alcotest_lwt.mli
+++ b/lwt/alcotest_lwt.mli
@@ -22,9 +22,9 @@ include Alcotest.Core.S with type return = unit Lwt.t
 
 val test_case :
   string ->
-  Alcotest.Core.speed_level ->
+  Alcotest.speed_level ->
   (Lwt_switch.t -> 'a -> unit Lwt.t) ->
   'a test_case
 
 val test_case' :
-  string -> Alcotest.Core.speed_level -> ('a -> unit) -> 'a test_case
+  string -> Alcotest.speed_level -> ('a -> unit) -> 'a test_case

--- a/src/core.ml
+++ b/src/core.ml
@@ -24,14 +24,14 @@ module IntSet = Set.Make (struct
   let compare : int -> int -> int = compare
 end)
 
-type speed_level = [ `Quick | `Slow ]
-
 exception Registration_error of string
 
 exception Check_error of string
 
 module type S = sig
   type return
+
+  type speed_level = [ `Quick | `Slow ]
 
   type 'a test_case = string * speed_level * ('a -> return)
 
@@ -69,6 +69,8 @@ module Make (M : Monad.S) = struct
   type 'a run = 'a -> unit M.t
 
   type path = Path of (string * int)
+
+  type speed_level = [ `Quick | `Slow ]
 
   exception Test_error
 

--- a/src/core.mli
+++ b/src/core.mli
@@ -16,14 +16,14 @@
 
 exception Check_error of string
 
-type speed_level = [ `Quick | `Slow ]
-(** Speed level of a test. Tests marked as [`Quick] are always run. Tests marked
-    as [`Slow] are skipped when the `-q` flag is passed. *)
-
 module IntSet : Set.S with type elt = int
 
 module type S = sig
   type return
+
+  type speed_level = [ `Quick | `Slow ]
+  (** Speed level of a test. Tests marked as [`Quick] are always run. Tests marked
+      as [`Slow] are skipped when the `-q` flag is passed. *)
 
   type 'a test_case = string * speed_level * ('a -> return)
   (** A test case is an UTF-8 encoded documentation string, a speed


### PR DESCRIPTION
We do not need to break the API here