### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/alcotest-async.opam
+++ b/alcotest-async.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune"  {build}
+  "dune"
   "ocaml" {>= "4.03.0"}
   "alcotest" {= version}
   "async_unix" {>= "v0.9.0"}

--- a/alcotest-lwt.opam
+++ b/alcotest-lwt.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune"  {build}
+  "dune"
   "ocaml" {>= "4.03.0"}
   "alcotest" {= version}
   "lwt" "logs"

--- a/alcotest.opam
+++ b/alcotest.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune"  {build & >= "1.1.0"}
+  "dune"  {>= "1.1.0"}
   "ocaml" {>= "4.03.0"}
   "fmt"   {>= "0.8.0"}
   "astring"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.