### PR TITLE
Refactor formatting logic

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,3 @@
 version = 0.11.0
 profile = conventional
+break-infix=fit-or-vertical

--- a/src/alcotest/cli.ml
+++ b/src/alcotest/cli.ml
@@ -110,7 +110,12 @@ module Make (M : Monad.S) : S with type return = unit M.t = struct
   let flags_with_defaults defaults =
     Term.(
       pure (v_runtime_flags ~defaults)
-      $ verbose $ compact $ show_errors $ quick_only $ json $ log_dir)
+      $ verbose
+      $ compact
+      $ show_errors
+      $ quick_only
+      $ json
+      $ log_dir)
 
   let regex =
     let parse s =
@@ -177,7 +182,10 @@ module Make (M : Monad.S) : S with type return = unit M.t = struct
         pure (run_test ~and_exit)
         $ flags
         $ pure (`Test_filter None)
-        $ set_color $ args $ pure library_name $ pure tests),
+        $ set_color
+        $ args
+        $ pure library_name
+        $ pure tests),
       Term.info exec_name ~doc )
 
   let test_cmd ~and_exit runtime_flags ~filter args library_name tests =
@@ -190,7 +198,12 @@ module Make (M : Monad.S) : S with type return = unit M.t = struct
     in
     ( Term.(
         pure (run_test ~and_exit)
-        $ flags $ filter $ set_color $ args $ pure library_name $ pure tests),
+        $ flags
+        $ filter
+        $ set_color
+        $ args
+        $ pure library_name
+        $ pure tests),
       Term.info "test" ~doc )
 
   let list_cmd tests =

--- a/src/alcotest/core.ml
+++ b/src/alcotest/core.ml
@@ -308,10 +308,11 @@ module Make (M : Monad.S) = struct
     | Invalid_argument f -> M.return @@ exn path "invalid" f
     | e -> M.return @@ exn path "exception" (Printexc.to_string e)
 
-  let perform_test t args Suite.{ path; fn; _ } =
-    let test = fn in
+  let perform_test t args suite =
+    let open Suite in
+    let test = suite.fn in
     let pp_event = pp_event t in
-    pp_event Fmt.stdout (`Start path);
+    pp_event Fmt.stdout (`Start suite.path);
     test args >|= fun result ->
     (* Store errors *)
     let () =
@@ -328,7 +329,7 @@ module Make (M : Monad.S) = struct
       in
       t.errors <- error @ t.errors
     in
-    pp_event Fmt.stdout (`Result (path, result));
+    pp_event Fmt.stdout (`Result (suite.path, result));
     result
 
   let perform_tests t tests args = M.List.map_s (perform_test t args) tests

--- a/src/alcotest/core.ml
+++ b/src/alcotest/core.ml
@@ -454,7 +454,11 @@ module Make (M : Monad.S) = struct
 
   (* Return the json for the api, dirty out, to avoid new dependencies *)
   let json_of_result r =
-    Printf.sprintf "{\"success\":%i,\"failures\":%i,\"time\":%f}" r.success
+    Fmt.strf {|{
+  "success": %i,
+  "failures": %i,
+  "time": %f
+}|} r.success
       r.failures r.time
 
   let s = function 0 | 1 -> "" | _ -> "s"

--- a/src/alcotest/output.ml
+++ b/src/alcotest/output.ml
@@ -1,0 +1,137 @@
+(*
+ * Copyright (c) 2013-2016 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2019      Craig Ferguson    <craig@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Astring
+
+type path = [ `Path of string * int ]
+
+type run_result =
+  [ `Ok
+  | `Exn of path * string * string
+  | `Error of path * string
+  | `Skip
+  | `Todo of string ]
+
+type event = [ `Result of path * run_result | `Start of path ]
+
+(* Colours *)
+let color c ppf fmt = Fmt.(styled c string) ppf fmt
+
+let cyan_s fmt = color `Cyan fmt
+
+let red_s fmt = color `Red fmt
+
+let red ppf fmt = Fmt.kstrf (fun str -> red_s ppf str) fmt
+
+let green_s fmt = color `Green fmt
+
+let yellow_s fmt = color `Yellow fmt
+
+let left_c = 20
+
+let left nb pp ppf a =
+  let s = Fmt.to_to_string pp a in
+  let nb = nb - String.length s in
+  if nb <= 0 then pp ppf a
+  else (
+    pp ppf a;
+    Fmt.string ppf (String.v ~len:nb (fun _ -> ' ')) )
+
+let pp_path ~max_label ppf (`Path (n, i)) =
+  Fmt.pf ppf "%a%3d" (left (max_label + 8) cyan_s) n i
+
+let pp_info ~max_label ~doc_of_path ppf p =
+  Fmt.pf ppf "%a   %s" (pp_path ~max_label) p (doc_of_path p)
+
+let pp_result ppf = function
+  | `Ok -> left left_c green_s ppf "[OK]"
+  | `Exn _ -> left left_c red_s ppf "[FAIL]"
+  | `Error _ -> left left_c red_s ppf "[ERROR]"
+  | `Skip -> left left_c yellow_s ppf "[SKIP]"
+  | `Todo _ -> left left_c yellow_s ppf "[TODO]"
+
+let pp_result_compact ppf result =
+  let char =
+    match result with
+    | `Ok -> '.'
+    | `Exn _ -> 'F'
+    | `Error _ -> 'E'
+    | `Skip -> 'S'
+    | `Todo _ -> 'T'
+  in
+  Fmt.char ppf char
+
+let pp_result_full ~max_label ~doc_of_path ppf (path, result) =
+  Fmt.pf ppf "%a%a" pp_result result (pp_info ~max_label ~doc_of_path) path
+
+let pp_event ~compact ~max_label ~doc_of_path ppf = function
+  | `Start _ when compact -> ()
+  | `Start p ->
+      left left_c yellow_s ppf " ...";
+      Fmt.pf ppf "%a" (pp_info ~max_label ~doc_of_path) p
+  | `Result (_, r) when compact -> Fmt.pr "%a" pp_result_compact r
+  | `Result (p, r) ->
+      Fmt.pf ppf "\r%a\n" (pp_result_full ~max_label ~doc_of_path) (p, r)
+
+type result = {
+  success : int;
+  failures : int;
+  time : float;
+  errors : string list;
+}
+
+let pp_suite_errors ~show_all ppf = function
+  | [] -> ()
+  | x :: xs ->
+      (if show_all then x :: xs else [ x ])
+      |> Fmt.pf ppf "%a\n" Fmt.(list ~sep:(const string "\n") string)
+
+let pp_plural ppf x = Fmt.pf ppf (if x < 2 then "" else "s")
+
+let pp_full_logs ppf log_dir =
+  Fmt.pf ppf "The full test results are available in `%s`.\n" log_dir
+
+let pp_summary ppf r =
+  let pp_failures ppf = function
+    | 0 -> green_s ppf "Test Successful"
+    | n -> red ppf "%d error%a!" n pp_plural n
+  in
+  Fmt.pf ppf "%a in %.3fs. %d test%a run.\n" pp_failures r.failures r.time
+    r.success pp_plural r.success
+
+let pp_suite_results ~verbose ~show_errors ~json ~compact ~log_dir ppf r =
+  let print_summary = (not compact) || r.failures > 0 in
+  match json with
+  | true ->
+      (* Return the json for the api, dirty out, to avoid new dependencies *)
+      Fmt.pf ppf {|{
+  "success": %i,
+  "failures": %i,
+  "time": %f
+}
+|}
+        r.success r.failures r.time
+  | false ->
+      Fmt.pf ppf "%a%a%a%a%!"
+        (if compact then Format.pp_force_newline else Fmt.nop)
+        ()
+        (pp_suite_errors ~show_all:(verbose || show_errors))
+        r.errors
+        (if print_summary && not verbose then pp_full_logs else Fmt.nop)
+        log_dir
+        (if print_summary then pp_summary else Fmt.nop)
+        r

--- a/src/alcotest/output.mli
+++ b/src/alcotest/output.mli
@@ -1,0 +1,49 @@
+(*
+ * Copyright (c) 2013-2016 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2019      Craig Ferguson    <craig@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+type path = [ `Path of string * int ]
+
+val pp_path : max_label:int -> path Fmt.t
+
+val pp_info : max_label:int -> doc_of_path:(path -> string) -> path Fmt.t
+
+type run_result =
+  [ `Ok
+  | `Exn of path * string * string
+  | `Error of path * string
+  | `Skip
+  | `Todo of string ]
+
+type event = [ `Result of path * run_result | `Start of path ]
+
+type result = {
+  success : int;
+  failures : int;
+  time : float;
+  errors : string list;
+}
+
+val pp_event :
+  compact:bool -> max_label:int -> doc_of_path:(path -> string) -> event Fmt.t
+
+val pp_suite_results :
+  verbose:bool ->
+  show_errors:bool ->
+  json:bool ->
+  compact:bool ->
+  log_dir:string ->
+  result Fmt.t

--- a/src/alcotest/pp.mli
+++ b/src/alcotest/pp.mli
@@ -17,9 +17,7 @@
 
 type path = [ `Path of string * int ]
 
-val pp_path : max_label:int -> path Fmt.t
-
-val pp_info : max_label:int -> doc_of_path:(path -> string) -> path Fmt.t
+val info : max_label:int -> doc_of_path:(path -> string) -> path Fmt.t
 
 type run_result =
   [ `Ok
@@ -37,10 +35,12 @@ type result = {
   errors : string list;
 }
 
-val pp_event :
+val rresult_error : run_result Fmt.t
+
+val event :
   compact:bool -> max_label:int -> doc_of_path:(path -> string) -> event Fmt.t
 
-val pp_suite_results :
+val suite_results :
   verbose:bool ->
   show_errors:bool ->
   json:bool ->

--- a/src/alcotest/utils.ml
+++ b/src/alcotest/utils.ml
@@ -1,6 +1,8 @@
 module List = struct
   include List
 
+  type 'a t = 'a list
+
   let filter_map f l =
     let rec inner acc = function
       | [] -> rev acc
@@ -20,4 +22,8 @@ module List = struct
         | Error e, Error acc -> Error (e :: acc)
         | Error e, Ok _ -> Error [ e ])
       l (Ok [])
+end
+
+module Result = struct
+  let map f = function Ok x -> Ok (f x) | Error e -> Error e
 end

--- a/src/alcotest/utils.ml
+++ b/src/alcotest/utils.ml
@@ -1,0 +1,23 @@
+module List = struct
+  include List
+
+  let filter_map f l =
+    let rec inner acc = function
+      | [] -> rev acc
+      | x :: xs -> (
+          match f x with
+          | None -> (inner [@tailcall]) acc xs
+          | Some y -> (inner [@tailcall]) (y :: acc) xs )
+    in
+    inner [] l
+
+  let lift_result l =
+    List.fold_right
+      (fun a b ->
+        match (a, b) with
+        | Ok o, Ok acc -> Ok (o :: acc)
+        | Ok _, Error e -> Error e
+        | Error e, Error acc -> Error (e :: acc)
+        | Error e, Ok _ -> Error [ e ])
+      l (Ok [])
+end

--- a/src/alcotest/utils.mli
+++ b/src/alcotest/utils.mli
@@ -1,0 +1,7 @@
+module List : sig
+  include module type of List
+
+  val filter_map : ('a -> 'b option) -> 'a list -> 'b list
+
+  val lift_result : ('a, 'b) result t -> ('a t, 'b t) result
+end

--- a/src/alcotest/utils.mli
+++ b/src/alcotest/utils.mli
@@ -1,7 +1,13 @@
 module List : sig
   include module type of List
 
+  type 'a t = 'a list
+
   val filter_map : ('a -> 'b option) -> 'a list -> 'b list
 
   val lift_result : ('a, 'b) result t -> ('a t, 'b t) result
+end
+
+module Result : sig
+  val map : ('a -> 'b) -> ('a, 'e) result -> ('b, 'e) result
 end

--- a/test/e2e/failing/check_basic.expected
+++ b/test/e2e/failing/check_basic.expected
@@ -1,0 +1,22 @@
+Testing failing testables.
+This run has ID `<uuid>`.
+ ...                different basic              0   bool.[FAIL]              different basic              0   bool.
+ ...                different basic              1   int.[FAIL]              different basic              1   int.
+ ...                different basic              2   int32.[FAIL]              different basic              2   int32.
+ ...                different basic              3   int64.[FAIL]              different basic              3   int64.
+ ...                different basic              4   float.[FAIL]              different basic              4   float.
+ ...                different basic              5   char.[FAIL]              different basic              5   char.
+ ...                different basic              6   string.[FAIL]              different basic              6   string.
+ ...                different composite          0   list.[FAIL]              different composite          0   list.
+ ...                different composite          1   array.[FAIL]              different composite          1   array.
+ ...                different composite          2   option some.[FAIL]              different composite          2   option some.
+ ...                different composite          3   result.[FAIL]              different composite          3   result.
+ ...                different composite          4   pair.[FAIL]              different composite          4   pair.
+-- different basic.000 [bool.] Failed --
+in `<build-context>/_build/_tests/<uuid>/different basic.000.output`:
+[failure] Error bool: expecting
+true, got
+false.
+
+The full test results are available in `<build-context>/_build/_tests/<uuid>`.
+12 errors! in <test-duration>s. 12 tests run.

--- a/test/e2e/failing/check_basic.ml
+++ b/test/e2e/failing/check_basic.ml
@@ -1,0 +1,30 @@
+(* Check that v of type [typ] matches with itself *)
+let id_case typ typ_str v1 v2 =
+  Alcotest.test_case typ_str `Quick (fun () ->
+      Alcotest.check typ typ_str v1 v2)
+
+let () =
+  let open Alcotest in
+  run "failing testables"
+    [
+      ( "different basic",
+        [
+          id_case bool "bool" true false;
+          id_case int "int" 1 2;
+          id_case int32 "int32" Int32.max_int Int32.min_int;
+          id_case int64 "int64" Int64.max_int Int64.min_int;
+          id_case (float 0.0) "float" 1.0 2.0;
+          id_case char "char" 'a' 'b';
+          id_case string "string" "Lorem ipsum" "dolor sit amet.";
+        ] );
+      ( "different composite",
+        [
+          id_case (list char) "list" [ 'a'; 'b' ] [ 'a'; 'c' ];
+          id_case (array int64) "array"
+            Int64.[| zero; max_int |]
+            Int64.[| zero; one; max_int |];
+          id_case (option int) "option some" (Some 1) (Some 2);
+          id_case (result int unit) "result" (Ok 1) (Error ());
+          id_case (pair int char) "pair" (1, 'a') (1, 'b');
+        ] );
+    ]

--- a/test/e2e/failing/dune.inc
+++ b/test/e2e/failing/dune.inc
@@ -1,12 +1,42 @@
 (executables
  (names
+   check_basic
    exception_in_test
+   invalid_arg_in_test
    unicode_testname
  )
  (libraries alcotest)
  (modules
+   check_basic
    exception_in_test
+   invalid_arg_in_test
    unicode_testname
+ )
+)
+
+(rule
+ (target check_basic.actual)
+ (action
+  (with-outputs-to %{target}
+   (run ../expect_failure.exe %{dep:check_basic.exe})
+  )
+ )
+)
+
+(rule
+ (target check_basic.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:check_basic.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff check_basic.expected check_basic.processed)
  )
 )
 
@@ -33,6 +63,32 @@
  (name runtest)
  (action
    (diff exception_in_test.expected exception_in_test.processed)
+ )
+)
+
+(rule
+ (target invalid_arg_in_test.actual)
+ (action
+  (with-outputs-to %{target}
+   (run ../expect_failure.exe %{dep:invalid_arg_in_test.exe})
+  )
+ )
+)
+
+(rule
+ (target invalid_arg_in_test.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:invalid_arg_in_test.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff invalid_arg_in_test.expected invalid_arg_in_test.processed)
  )
 )
 

--- a/test/e2e/failing/exception_in_test.expected
+++ b/test/e2e/failing/exception_in_test.expected
@@ -8,4 +8,4 @@ in `<build-context>/_build/_tests/<uuid>/test-a.001.output`:
 [invalid] Failing test
 
 The full test results are available in `<build-context>/_build/_tests/<uuid>`.
-1 error! in 0.000s. 3 tests run.
+1 error! in <test-duration>s. 3 tests run.

--- a/test/e2e/failing/invalid_arg_in_test.expected
+++ b/test/e2e/failing/invalid_arg_in_test.expected
@@ -5,7 +5,7 @@ This run has ID `<uuid>`.
  ...                test-b          0   Another pass.[OK]                test-b          0   Another pass.
 -- test-a.001 [Failing.] Failed --
 in `<build-context>/_build/_tests/<uuid>/test-a.001.output`:
-[exception] Exception_in_test.Foo("message")
+[invalid] Failing test
 
 The full test results are available in `<build-context>/_build/_tests/<uuid>`.
 1 error! in <test-duration>s. 3 tests run.

--- a/test/e2e/failing/invalid_arg_in_test.ml
+++ b/test/e2e/failing/invalid_arg_in_test.ml
@@ -1,5 +1,3 @@
-exception Foo of string
-
 let () =
   let open Alcotest in
   run "suite-with-failures"
@@ -7,7 +5,7 @@ let () =
       ( "test-a",
         [
           test_case "Passing" `Quick (fun () -> ());
-          test_case "Failing" `Quick (fun () -> raise (Foo "message"));
+          test_case "Failing" `Quick (fun () -> invalid_arg "Failing test");
         ] );
       ("test-b", [ test_case "Another pass" `Quick (fun () -> ()) ]);
     ]

--- a/test/e2e/gen_dune_rules.ml
+++ b/test/e2e/gen_dune_rules.ml
@@ -77,7 +77,9 @@ let example_alias_stanza filename =
 let is_example filename = Filename.check_suffix filename ".ml"
 
 let main expect_failure =
-  Sys.readdir "." |> Array.to_list |> List.sort String.compare
+  Sys.readdir "."
+  |> Array.to_list
+  |> List.sort String.compare
   |> List.filter is_example
   |> function
   | [] -> () (* no tests to execute *)

--- a/test/e2e/passing/json_output.expected
+++ b/test/e2e/passing/json_output.expected
@@ -1,3 +1,7 @@
-{"success":3,"failures":0,"time":0.000000}
+{
+  "success": 3,
+  "failures": 0,
+  "time": 0.000000
+}
 Testing suite-name.
 This run has ID `<uuid>`.

--- a/test/e2e/passing/json_output.expected
+++ b/test/e2e/passing/json_output.expected
@@ -1,7 +1,7 @@
+Testing suite-name.
+This run has ID `<uuid>`.
 {
   "success": 3,
   "failures": 0,
   "time": 0.000000
 }
-Testing suite-name.
-This run has ID `<uuid>`.

--- a/test/e2e/passing/list_tests.expected
+++ b/test/e2e/passing/list_tests.expected
@@ -1,3 +1,3 @@
-test-a          0    alpha.
-test-a          1    beta.
-test-b          0    lorem ipsum dolor sit amet consectutor adipiscing elit.
+test-a          0   alpha.
+test-a          1   beta.
+test-b          0   lorem ipsum dolor sit amet consectutor adipiscing elit.

--- a/test/e2e/strip_randomness.ml
+++ b/test/e2e/strip_randomness.ml
@@ -26,15 +26,21 @@ let time_replace =
   let t =
     seq
       [
-        str "Test Successful in ";
-        rep1 Re.digit;
+        group
+          (alt
+             [
+               str "Test Successful in ";
+               seq [ rep1 digit; str " error! in " ];
+               seq [ rep1 digit; str " errors! in " ];
+             ]);
+        rep1 digit;
         char '.';
-        rep1 Re.digit;
+        rep1 digit;
         char 's';
       ]
   in
   let re = compile t in
-  replace_string ~all:true re ~by:"Test Successful in <test-duration>s"
+  replace ~all:true re ~f:(fun g -> Group.get g 1 ^ "<test-duration>s")
 
 (* Remove all non-deterministic output in a given Alcotest log and write
    the result to std.out *)

--- a/test/e2e/strip_randomness.ml
+++ b/test/e2e/strip_randomness.ml
@@ -49,7 +49,9 @@ let () =
   try
     let rec loop () =
       let sanitized_line =
-        input_line in_channel |> uuid_replace |> build_context_replace
+        input_line in_channel
+        |> uuid_replace
+        |> build_context_replace
         |> time_replace
       in
       Printf.printf "%s\n" sanitized_line;


### PR DESCRIPTION
An assorted collection of improvements/refactorings aimed at extracting more logic from the `Core` module. Mostly consists of splitting out pretty-printers for the output values and keeping them separate from the `Core.t` type, which is currently very overloaded.