### PR TITLE
Fix CI for OCaml 4.03

### DIFF
--- a/test/e2e/gen_dune_rules.ml
+++ b/test/e2e/gen_dune_rules.ml
@@ -1,5 +1,22 @@
+(* Copied from Filename (stdlib) for pre-4.04 compatibility *)
+let chop_extension name =
+  let is_dir_sep s i =
+    match Sys.os_type with
+    | "Unix" -> s.[i] = '/'
+    | "Win32" | "Cygwin" ->
+        let c = s.[i] in
+        c = '/' || c = '\\' || c = ':'
+    | _ -> assert false
+  in
+  let rec search_dot i =
+    if i < 0 || is_dir_sep name i then invalid_arg "Filename.chop_extension"
+    else if name.[i] = '.' then String.sub name 0 i
+    else search_dot (i - 1)
+  in
+  search_dot (String.length name - 1)
+
 let global_stanza filenames =
-  let bases = List.map Filename.remove_extension filenames in
+  let bases = List.map chop_extension filenames in
   let pp_sexp_list = Fmt.(list ~sep:(const string "\n   ")) in
   Fmt.pr
     {|(executables
@@ -15,7 +32,7 @@ let global_stanza filenames =
     (pp_sexp_list Fmt.string) bases (pp_sexp_list Fmt.string) bases
 
 let example_rule_stanza ~expect_failure filename =
-  let base = Filename.remove_extension filename in
+  let base = chop_extension filename in
   let expect_failure =
     if expect_failure then "../expect_failure.exe " else ""
   in
@@ -45,7 +62,7 @@ let example_rule_stanza ~expect_failure filename =
     base expect_failure base base base
 
 let example_alias_stanza filename =
-  let base = Filename.remove_extension filename in
+  let base = chop_extension filename in
   Fmt.pr
     {|
 (alias

--- a/test/e2e/passing/check_basic.ml
+++ b/test/e2e/passing/check_basic.ml
@@ -9,13 +9,16 @@ let make_checks () =
   check int "int " 0 0;
   check int32
 
+exception Zero
+
+exception One of int
+
+exception Two of int * char
+
 let checked_exceptions () =
   let check_refl name exn =
     Alcotest.check_raises name exn (fun () -> raise exn)
   in
-  let exception Zero in
-  let exception One of int in
-  let exception Two of int * char in
   check_refl "0-tuple" Zero;
   check_refl "1-tuple" (One 1);
   check_refl "2-tuple" (Two (1, 'a'))


### PR DESCRIPTION
Fixes two minor issues preventing the CI from being able to test Alcotest core on OCaml 4.03.