### PR TITLE
Show at most 100 lines of output for a failed test.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
   without use of the `argv` parameter. (#182, @CraigFe)
 - Add `--compact` option for more concise result reporting. (#149,
   @andersfugmann)
+- Add `--tail-errors` option for limiting the size of error logs printed to
+  standard output. (#200, @mjambon)
 - Add support for executing subsets of tests via the `test` subcommand. (#158,
   @CraigFe)
 - Change the `float` check to include equality of `isNaN` and infinities. See

--- a/examples/simple.ml
+++ b/examples/simple.ml
@@ -53,6 +53,12 @@ let test_list_concat () =
     "same lists" [ 1; 2; 3 ]
     (To_test.list_concat [ 1 ] [ 2; 3 ])
 
+let test_error_output () =
+  for i = 1 to 1000 do
+    Printf.printf "output line %i\n" i
+  done;
+  Alcotest.fail "This was supposed to fail."
+
 (* Run it *)
 let () =
   Alcotest.run "Utils"
@@ -66,4 +72,6 @@ let () =
         [ Alcotest.test_case "String mashing" `Quick test_str_concat ] );
       ( "list-concat",
         [ Alcotest.test_case "List mashing" `Slow test_list_concat ] );
+      ( "fail-big-output",
+        [ Alcotest.test_case "Error output" `Quick test_error_output ] );
     ]

--- a/examples/simple.ml
+++ b/examples/simple.ml
@@ -53,12 +53,6 @@ let test_list_concat () =
     "same lists" [ 1; 2; 3 ]
     (To_test.list_concat [ 1 ] [ 2; 3 ])
 
-let test_error_output () =
-  for i = 1 to 1000 do
-    Printf.printf "output line %i\n" i
-  done;
-  Alcotest.fail "This was supposed to fail."
-
 (* Run it *)
 let () =
   Alcotest.run "Utils"
@@ -72,6 +66,4 @@ let () =
         [ Alcotest.test_case "String mashing" `Quick test_str_concat ] );
       ( "list-concat",
         [ Alcotest.test_case "List mashing" `Slow test_list_concat ] );
-      ( "fail-big-output",
-        [ Alcotest.test_case "Error output" `Quick test_error_output ] );
     ]

--- a/src/alcotest/cli.ml
+++ b/src/alcotest/cli.ml
@@ -100,12 +100,12 @@ module Make (M : Monad.S) : S with type return = unit M.t = struct
     match s with
     | "unlimited" -> Ok `Unlimited
     | s -> (
-        match int_of_string_opt s with
-        | Some n ->
-            if n < 0 then
-              Error (`Msg "numeric limit must be nonnegative or 'unlimited'")
-            else Ok (`Limit n)
-        | None -> Error (`Msg "invalid numeric limit") )
+        try
+          let n = int_of_string s in
+          if n < 0 then
+            Error (`Msg "numeric limit must be nonnegative or 'unlimited'")
+          else Ok (`Limit n)
+        with Failure _ -> Error (`Msg "invalid numeric limit") )
 
   let limit_printer ppf limit =
     match limit with

--- a/src/alcotest/cli.mli
+++ b/src/alcotest/cli.mli
@@ -52,7 +52,7 @@ module type S = sig
     return)
     with_options
   (** [run_with_args n a t] Similar to [run a t] but take an extra
-      argument [a]. Every test function will receive as arguement the
+      argument [a]. Every test function will receive as argument the
       evaluation of the [Cdmliner] term [a]: this is useful to configure
       the test behaviors using the CLI. *)
 end

--- a/src/alcotest/core.ml
+++ b/src/alcotest/core.ml
@@ -230,7 +230,8 @@ module Make (M : Monad.S) = struct
       let display_lines =
         if omitted_count = 0 then selected_lines
         else
-          Printf.sprintf "... (omitting %i lines)" omitted_count
+          Fmt.strf "... (omitting %i line%a)" omitted_count Pp.pp_plural
+            omitted_count
           :: selected_lines
       in
       String.concat ~sep:"\n" display_lines ^ "\n"

--- a/src/alcotest/core.ml
+++ b/src/alcotest/core.ml
@@ -48,7 +48,7 @@ module type S = sig
     ?and_exit:bool ->
     ?verbose:bool ->
     ?compact:bool ->
-    ?max_log_lines:int option ->
+    ?tail_errors:int option ->
     ?quick_only:bool ->
     ?show_errors:bool ->
     ?json:bool ->
@@ -162,7 +162,7 @@ module Make (M : Monad.S) = struct
     json : bool;
     verbose : bool;
     compact : bool;
-    max_log_lines : int option;
+    tail_errors : int option;
     log_dir : string;
     run_id : string;
   }
@@ -174,7 +174,7 @@ module Make (M : Monad.S) = struct
     let max_label = 0 in
     let verbose = false in
     let compact = false in
-    let max_log_lines = None in
+    let tail_errors = None in
     let speed_level = `Slow in
     let show_errors = false in
     let json = false in
@@ -190,7 +190,7 @@ module Make (M : Monad.S) = struct
       json;
       verbose;
       compact;
-      max_log_lines;
+      tail_errors;
       log_dir;
       run_id;
     }
@@ -300,14 +300,14 @@ module Make (M : Monad.S) = struct
 
   let bold_s fmt = color `Bold fmt
 
-  let pp_error ~verbose ~doc_of_path ~output_file ~max_log_lines ppf
+  let pp_error ~verbose ~doc_of_path ~output_file ~tail_errors ppf
       (path, error) =
     let logs =
       let filename = output_file path in
       if verbose || not (Sys.file_exists filename) then Fmt.strf "%s\n" error
       else
         let file = open_in filename in
-        let output = read_tail ~max_lines:max_log_lines file in
+        let output = read_tail ~max_lines:tail_errors file in
         close_in file;
         Fmt.strf "in `%s`:\n%s" filename output
     in
@@ -350,7 +350,7 @@ module Make (M : Monad.S) = struct
       let pp_error =
         pp_error ~verbose:t.verbose
           ~doc_of_path:(Suite.doc_of_path t.suite)
-          ~output_file:(output_file t) ~max_log_lines:t.max_log_lines
+          ~output_file:(output_file t) ~tail_errors:t.tail_errors
       in
       let error =
         match result with
@@ -504,7 +504,7 @@ module Make (M : Monad.S) = struct
     ?and_exit:bool ->
     ?verbose:bool ->
     ?compact:bool ->
-    ?max_log_lines:int option ->
+    ?tail_errors:int option ->
     ?quick_only:bool ->
     ?show_errors:bool ->
     ?json:bool ->
@@ -513,7 +513,7 @@ module Make (M : Monad.S) = struct
     'a
 
   let run_with_args ?(and_exit = true) ?(verbose = false) ?(compact = false)
-      ?(max_log_lines = None) ?(quick_only = false) ?(show_errors = false)
+      ?(tail_errors = None) ?(quick_only = false) ?(show_errors = false)
       ?(json = false) ?filter ?(log_dir = default_log_dir ()) name args
       (tl : 'a test list) =
     let speed_level = if quick_only then `Quick else `Slow in
@@ -526,7 +526,7 @@ module Make (M : Monad.S) = struct
         name;
         verbose;
         compact;
-        max_log_lines;
+        tail_errors;
         speed_level;
         json;
         show_errors;
@@ -548,8 +548,8 @@ module Make (M : Monad.S) = struct
         | _, true -> exit 1
         | _, false -> raise Test_error )
 
-  let run ?and_exit ?verbose ?compact ?max_log_lines ?quick_only ?show_errors
+  let run ?and_exit ?verbose ?compact ?tail_errors ?quick_only ?show_errors
       ?json ?filter ?log_dir name (tl : unit test list) =
-    run_with_args ?and_exit ?verbose ?compact ?max_log_lines ?quick_only
+    run_with_args ?and_exit ?verbose ?compact ?tail_errors ?quick_only
       ?show_errors ?json ?filter ?log_dir name () tl
 end

--- a/src/alcotest/core.mli
+++ b/src/alcotest/core.mli
@@ -48,7 +48,7 @@ module type S = sig
     ?and_exit:bool ->
     ?verbose:bool ->
     ?compact:bool ->
-    ?max_log_lines:int option ->
+    ?tail_errors:int option ->
     ?quick_only:bool ->
     ?show_errors:bool ->
     ?json:bool ->
@@ -63,7 +63,7 @@ module type S = sig
       - [verbose] (default [false]). Display the test std.out and std.err (rather
         than redirecting to a log file).
       - [compact] (default [false]). Compact the output of the tests.
-      - [max_log_lines] (default unlimited). Show only the last N lines of
+      - [tail_errors] (default unlimited). Show only the last N lines of
         output of failed tests.
       - [quick_only] (default [false]). Don't run tests with the
         {{!Core.speed_level} [`Slow] speed level}.

--- a/src/alcotest/core.mli
+++ b/src/alcotest/core.mli
@@ -48,6 +48,7 @@ module type S = sig
     ?and_exit:bool ->
     ?verbose:bool ->
     ?compact:bool ->
+    ?max_log_lines:int option ->
     ?quick_only:bool ->
     ?show_errors:bool ->
     ?json:bool ->
@@ -62,6 +63,8 @@ module type S = sig
       - [verbose] (default [false]). Display the test std.out and std.err (rather
         than redirecting to a log file).
       - [compact] (default [false]). Compact the output of the tests.
+      - [max_log_lines] (default unlimited). Show only the last N lines of
+        output of failed tests.
       - [quick_only] (default [false]). Don't run tests with the
         {{!Core.speed_level} [`Slow] speed level}.
       - [show_errors] (default [false]). Display the test errors.

--- a/src/alcotest/core.mli
+++ b/src/alcotest/core.mli
@@ -48,7 +48,7 @@ module type S = sig
     ?and_exit:bool ->
     ?verbose:bool ->
     ?compact:bool ->
-    ?tail_errors:int option ->
+    ?tail_errors:[ `Unlimited | `Limit of int ] ->
     ?quick_only:bool ->
     ?show_errors:bool ->
     ?json:bool ->

--- a/src/alcotest/pp.mli
+++ b/src/alcotest/pp.mli
@@ -47,3 +47,11 @@ val suite_results :
   compact:bool ->
   log_dir:string ->
   result Fmt.t
+
+val pp_plural : Format.formatter -> int -> unit
+(** This is for adding an 's' to words that should be pluralized, e.g.
+{[
+     let n = List.length items in
+     Fmt.pr "Found %i item%a." n pp_plural n
+]}
+*)

--- a/test/e2e/failing/dune.inc
+++ b/test/e2e/failing/dune.inc
@@ -4,6 +4,8 @@
    compact
    exception_in_test
    invalid_arg_in_test
+   tail_errors_limit
+   tail_errors_unlimited
    unicode_testname
  )
  (libraries alcotest)
@@ -12,6 +14,8 @@
    compact
    exception_in_test
    invalid_arg_in_test
+   tail_errors_limit
+   tail_errors_unlimited
    unicode_testname
  )
 )
@@ -117,6 +121,58 @@
  (name runtest)
  (action
    (diff invalid_arg_in_test.expected invalid_arg_in_test.processed)
+ )
+)
+
+(rule
+ (target tail_errors_limit.actual)
+ (action
+  (with-outputs-to %{target}
+   (run ../expect_failure.exe %{dep:tail_errors_limit.exe})
+  )
+ )
+)
+
+(rule
+ (target tail_errors_limit.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:tail_errors_limit.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff tail_errors_limit.expected tail_errors_limit.processed)
+ )
+)
+
+(rule
+ (target tail_errors_unlimited.actual)
+ (action
+  (with-outputs-to %{target}
+   (run ../expect_failure.exe %{dep:tail_errors_unlimited.exe})
+  )
+ )
+)
+
+(rule
+ (target tail_errors_unlimited.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../strip_randomness.exe %{dep:tail_errors_unlimited.actual})
+  )
+ )
+)
+
+
+(alias
+ (name runtest)
+ (action
+   (diff tail_errors_unlimited.expected tail_errors_unlimited.processed)
  )
 )
 

--- a/test/e2e/failing/tail_errors_limit.expected
+++ b/test/e2e/failing/tail_errors_limit.expected
@@ -1,0 +1,20 @@
+Testing tail_errors_limit.
+This run has ID `<uuid>`.
+ ...                failing          0   test.[ERROR]             failing          0   test.
+-- failing.000 [test.] Failed --
+in `<build-context>/_build/_tests/<uuid>/failing.000.output`:
+... (omitting 91 lines)
+output line 92
+output line 93
+output line 94
+output line 95
+output line 96
+output line 97
+output line 98
+output line 99
+output line 100
+Test error: Error Logs above should be 10 lines long (omitting 91)..
+
+The full test results are available in `<build-context>/_build/_tests/<uuid>`.
+1 error! in <test-duration>s. 1 test run.
+ASSERT Logs above should be 10 lines long (omitting 91).

--- a/test/e2e/failing/tail_errors_limit.ml
+++ b/test/e2e/failing/tail_errors_limit.ml
@@ -1,0 +1,10 @@
+let test_error_output () =
+  for i = 1 to 100 do
+    Printf.printf "output line %i\n" i
+  done;
+  Alcotest.fail "Logs above should be 10 lines long (omitting 91)."
+
+let () =
+  let open Alcotest in
+  run ~tail_errors:(`Limit 10) "tail_errors_limit"
+    [ ("failing", [ test_case "test" `Quick test_error_output ]) ]

--- a/test/e2e/failing/tail_errors_unlimited.expected
+++ b/test/e2e/failing/tail_errors_unlimited.expected
@@ -1,0 +1,110 @@
+Testing tail_errors_unlimited.
+This run has ID `<uuid>`.
+ ...                failing          0   test.[ERROR]             failing          0   test.
+-- failing.000 [test.] Failed --
+in `<build-context>/_build/_tests/<uuid>/failing.000.output`:
+output line 1
+output line 2
+output line 3
+output line 4
+output line 5
+output line 6
+output line 7
+output line 8
+output line 9
+output line 10
+output line 11
+output line 12
+output line 13
+output line 14
+output line 15
+output line 16
+output line 17
+output line 18
+output line 19
+output line 20
+output line 21
+output line 22
+output line 23
+output line 24
+output line 25
+output line 26
+output line 27
+output line 28
+output line 29
+output line 30
+output line 31
+output line 32
+output line 33
+output line 34
+output line 35
+output line 36
+output line 37
+output line 38
+output line 39
+output line 40
+output line 41
+output line 42
+output line 43
+output line 44
+output line 45
+output line 46
+output line 47
+output line 48
+output line 49
+output line 50
+output line 51
+output line 52
+output line 53
+output line 54
+output line 55
+output line 56
+output line 57
+output line 58
+output line 59
+output line 60
+output line 61
+output line 62
+output line 63
+output line 64
+output line 65
+output line 66
+output line 67
+output line 68
+output line 69
+output line 70
+output line 71
+output line 72
+output line 73
+output line 74
+output line 75
+output line 76
+output line 77
+output line 78
+output line 79
+output line 80
+output line 81
+output line 82
+output line 83
+output line 84
+output line 85
+output line 86
+output line 87
+output line 88
+output line 89
+output line 90
+output line 91
+output line 92
+output line 93
+output line 94
+output line 95
+output line 96
+output line 97
+output line 98
+output line 99
+output line 100
+Test error: Error Logs above should be 101 lines long..
+
+The full test results are available in `<build-context>/_build/_tests/<uuid>`.
+1 error! in <test-duration>s. 1 test run.
+ASSERT Logs above should be 101 lines long.

--- a/test/e2e/failing/tail_errors_unlimited.ml
+++ b/test/e2e/failing/tail_errors_unlimited.ml
@@ -1,0 +1,10 @@
+let test_error_output () =
+  for i = 1 to 100 do
+    Printf.printf "output line %i\n" i
+  done;
+  Alcotest.fail "Logs above should be 101 lines long."
+
+let () =
+  let open Alcotest in
+  run ~tail_errors:`Unlimited "tail_errors_unlimited"
+    [ ("failing", [ test_case "test" `Quick test_error_output ]) ]


### PR DESCRIPTION
This implements what I suggested in https://github.com/mirage/alcotest/issues/199

The goal is to declutter the console output when a verbose test fails.

This implementation uses a fixed limit of 100 lines. I didn't add a test because I'm not sure how check for the expected output at minimal effort. Here's a simple test to see what happens:
```ocaml
let test_error_output () =
  for i = 1 to 1000 do
    Printf.printf "output line %i\n" i
  done;
  Alcotest.fail "This was supposed to fail."
```
When adding this test to `examples/simple.ml`, we get the following output:
```
$ cd _build/default/examples && ./simple.exe
Testing Utils.
This run has ID `80588429-621C-4BF9-8CD4-93D70A7BD0A9`.
[OK]                string-case              0   Lower case.
[OK]                string-case              1   Capitalization.
[OK]                string-concat            0   String mashing.
[OK]                list-concat              0   List mashing.
[ERROR]             fail-big-output          0   Error output.
-- fail-big-output.000 [Error output.] Failed --
in `/mnt/sandisk256-main/martin/shared/dev/friends/alcotest/_build/default/examples/_build/_tests/80588429-621C-4BF9-8CD4-93D70A7BD0A9/fail-big-output.000.output`:
... (omitting 906 lines)
output line 907
output line 908
output line 909
output line 910
output line 911
output line 912
output line 913
output line 914
output line 915
output line 916
output line 917
output line 918
output line 919
output line 920
output line 921
output line 922
output line 923
output line 924
output line 925
output line 926
output line 927
output line 928
output line 929
output line 930
output line 931
output line 932
output line 933
output line 934
output line 935
output line 936
output line 937
output line 938
output line 939
output line 940
output line 941
output line 942
output line 943
output line 944
output line 945
output line 946
output line 947
output line 948
output line 949
output line 950
output line 951
output line 952
output line 953
output line 954
output line 955
output line 956
output line 957
output line 958
output line 959
output line 960
output line 961
output line 962
output line 963
output line 964
output line 965
output line 966
output line 967
output line 968
output line 969
output line 970
output line 971
output line 972
output line 973
output line 974
output line 975
output line 976
output line 977
output line 978
output line 979
output line 980
output line 981
output line 982
output line 983
output line 984
output line 985
output line 986
output line 987
output line 988
output line 989
output line 990
output line 991
output line 992
output line 993
output line 994
output line 995
output line 996
output line 997
output line 998
output line 999
output line 1000
Test error: Error This was supposed to fail..
ASSERT same string
ASSERT same string
ASSERT same string
ASSERT same lists
ASSERT This was supposed to fail.

The full test results are available in `/mnt/sandisk256-main/martin/shared/dev/friends/alcotest/_build/default/examples/_build/_tests/80588429-621C-4BF9-8CD4-93D70A7BD0A9`.
1 error! in 0.000s. 5 tests run.
```
