### PR TITLE
Rename test_case' functions to test_case_sync

### DIFF
--- a/examples/lwt/test.ml
+++ b/examples/lwt/test.ml
@@ -89,12 +89,12 @@ let () =
        [
          ( "basic",
            [
-             test_case' "Plain" `Quick test_lowercase;
+             test_case_sync "Plain" `Quick test_lowercase;
              test_case "Lwt" `Quick test_lowercase_lwt;
            ] );
          ( "exceptions",
            [
-             test_case' "Plain" `Quick test_exn;
+             test_case_sync "Plain" `Quick test_exn;
              test_case "Lwt toplevel" `Quick test_exn_lwt_toplevel;
              test_case "Lwt internal" `Quick test_exn_lwt_internal;
            ] );

--- a/src/alcotest-async/alcotest_async.ml
+++ b/src/alcotest-async/alcotest_async.ml
@@ -10,7 +10,7 @@ end)
 
 include Tester
 
-let test_case' n s f = test_case n s (fun x -> Deferred.return (f x))
+let test_case_sync n s f = test_case n s (fun x -> Deferred.return (f x))
 
 let run_test timeout name fn args =
   Clock.with_timeout timeout (fn args) >>| function

--- a/src/alcotest-async/alcotest_async.mli
+++ b/src/alcotest-async/alcotest_async.mli
@@ -26,4 +26,5 @@ val test_case :
   ('a -> unit Async_kernel.Deferred.t) ->
   'a test_case
 
-val test_case' : string -> Alcotest.speed_level -> ('a -> unit) -> 'a test_case
+val test_case_sync :
+  string -> Alcotest.speed_level -> ('a -> unit) -> 'a test_case

--- a/src/alcotest-lwt/alcotest_lwt.ml
+++ b/src/alcotest-lwt/alcotest_lwt.ml
@@ -17,7 +17,7 @@
 module Tester = Alcotest.Core.Make (Lwt)
 include Tester
 
-let test_case' n s f = test_case n s (fun x -> Lwt.return (f x))
+let test_case_sync n s f = test_case n s (fun x -> Lwt.return (f x))
 
 let run_test fn args =
   let async_ex, async_waker = Lwt.wait () in

--- a/src/alcotest-lwt/alcotest_lwt.mli
+++ b/src/alcotest-lwt/alcotest_lwt.mli
@@ -26,4 +26,5 @@ val test_case :
   (Lwt_switch.t -> 'a -> unit Lwt.t) ->
   'a test_case
 
-val test_case' : string -> Alcotest.speed_level -> ('a -> unit) -> 'a test_case
+val test_case_sync :
+  string -> Alcotest.speed_level -> ('a -> unit) -> 'a test_case


### PR DESCRIPTION
The original names for these (introduced by https://github.com/mirage/alcotest/pull/202) are embarrassingly unhelpful. New names as proposed by @aantron: https://github.com/mirage/alcotest/pull/167#issuecomment-518565934.