### PR TITLE
Make transitive dependencies explicit in dune files

### DIFF
--- a/alcotest.opam
+++ b/alcotest.opam
@@ -21,6 +21,7 @@ depends: [
   "cmdliner"
   "uuidm"
   "re"
+  "stdlib-shims"
 ]
 
 synopsis: "Alcotest is a lightweight and colourful test framework"

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,4 @@
 (lang dune 1.11)
 (name alcotest)
 (using fmt 1.0)
+(implicit_transitive_deps false)

--- a/examples/bad/dune
+++ b/examples/bad/dune
@@ -1,6 +1,6 @@
 (executable
  (name bad)
- (libraries alcotest))
+ (libraries alcotest astring))
 
 ; This fails at runtime, so just build the executable
 

--- a/examples/lwt/dune
+++ b/examples/lwt/dune
@@ -1,4 +1,4 @@
 (tests
  (names test)
  (package alcotest-lwt)
- (libraries alcotest-lwt))
+ (libraries alcotest alcotest-lwt lwt lwt.unix))

--- a/src/alcotest-async/dune
+++ b/src/alcotest-async/dune
@@ -1,4 +1,4 @@
 (library
   (name        alcotest_async)
   (public_name alcotest-async)
-  (libraries   alcotest core_kernel async_unix))
+  (libraries   alcotest async_kernel async_unix base core core_kernel))

--- a/src/alcotest-lwt/dune
+++ b/src/alcotest-lwt/dune
@@ -1,4 +1,4 @@
 (library
   (name        alcotest_lwt)
   (public_name alcotest-lwt)
-  (libraries   logs lwt.unix alcotest))
+  (libraries   logs lwt lwt.unix fmt alcotest))

--- a/src/alcotest/dune
+++ b/src/alcotest/dune
@@ -1,3 +1,3 @@
 (library
  (public_name alcotest)
- (libraries   fmt astring cmdliner fmt.cli fmt.tty uuidm re))
+ (libraries   fmt astring cmdliner fmt.cli fmt.tty uuidm re stdlib-shims))


### PR DESCRIPTION
Reviving https://github.com/mirage/alcotest/pull/197 with a new explicit dependency on `stdlib-shims` to eliminate the blockers there.