### PR TITLE
Add support for environment variable ALCOTEST_COLOR

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+- Add support for an `ALCOTEST_COLOR={auto,always,never}` environment variable
+  to control the colorization of terminal output. (#209, @mjambon)
+
 ### 1.0.0 (2019-01-14)
 
 - Require OCaml 4.03. (#159, @hannesm)

--- a/src/alcotest/cli.ml
+++ b/src/alcotest/cli.ml
@@ -40,7 +40,9 @@ module Make (M : Monad.S) : S with type return = unit M.t = struct
 
   let set_color style_renderer = Fmt_tty.setup_std_outputs ?style_renderer ()
 
-  let set_color = Term.(const set_color $ Fmt_cli.style_renderer ())
+  let set_color =
+    let env = Arg.env_var "ALCOTEST_COLOR" in
+    Term.(const set_color $ Fmt_cli.style_renderer ~env ())
 
   type runtime_options = {
     verbose : bool;


### PR DESCRIPTION
This offers an alternate way to specify color output, consistent with other options. See #207 . It just works. I don't think this needs a test since it's really just one call to an external function.