### PR TITLE
Add assert message to err only in case of failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+- Remove the extra asserts printed sometimes after the results of a test. (#215,
+  @icristescu)
+
 ### 1.0.1 (2020-02-12)
 
 - Add support for an `ALCOTEST_COLOR={auto,always,never}` environment variable

--- a/src/alcotest/alcotest.ml
+++ b/src/alcotest/alcotest.ml
@@ -146,9 +146,9 @@ let check_err fmt =
   Format.ksprintf (fun err -> raise (Core.Check_error err)) fmt
 
 let check t msg x y =
-  show_assert msg;
   if not (equal t x y) then
-    Fmt.strf "Error %s: expecting@\n%a, got@\n%a." msg (pp t) x (pp t) y
+    ( show_assert msg;
+      Fmt.strf "Error %s: expecting@\n%a, got@\n%a." msg (pp t) x (pp t) y )
     |> failwith
 
 let fail msg =
@@ -166,14 +166,15 @@ let collect_exception f =
   with e -> Some e
 
 let check_raises msg exn f =
-  show_assert msg;
   match collect_exception f with
   | None ->
+      show_assert msg;
       check_err "Fail %s: expecting %s, got nothing." msg
         (Printexc.to_string exn)
   | Some e ->
-      if e <> exn then
+      if e <> exn then (
+        show_assert msg;
         check_err "Fail %s: expecting %s, got %s." msg (Printexc.to_string exn)
-          (Printexc.to_string e)
+          (Printexc.to_string e) )
 
 let () = at_exit (Format.pp_print_flush Format.err_formatter)

--- a/test/e2e/alcotest/passing/check_basic.expected
+++ b/test/e2e/alcotest/passing/check_basic.expected
@@ -23,6 +23,3 @@ This run has ID `<uuid>`.
  ...                fuzzy equality               1   sorted list.[OK]                fuzzy equality               1   sorted list.
 The full test results are available in `<build-context>/_build/_tests/<uuid>`.
 Test Successful in <test-duration>s. 21 tests run.
-ASSERT 0-tuple
-ASSERT 1-tuple
-ASSERT 2-tuple

--- a/test/e2e/alcotest/passing/check_basic.expected
+++ b/test/e2e/alcotest/passing/check_basic.expected
@@ -23,3 +23,6 @@ This run has ID `<uuid>`.
  ...                fuzzy equality               1   sorted list.[OK]                fuzzy equality               1   sorted list.
 The full test results are available in `<build-context>/_build/_tests/<uuid>`.
 Test Successful in <test-duration>s. 21 tests run.
+ASSERT 0-tuple
+ASSERT 1-tuple
+ASSERT 2-tuple


### PR DESCRIPTION
This prevents printing extra assert messages after running the tests. (you can see this behaviour before the fix, by running  `example/simple.ml`). 