### PR TITLE
Tighten lower bound on Fmt for new result combinator

### DIFF
--- a/alcotest.opam
+++ b/alcotest.opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.03.0"}
-  "fmt" {>= "0.8.0"}
+  "fmt" {>= "0.8.6"}
   "astring"
   "cmdliner"
   "uuidm"

--- a/dune-project
+++ b/dune-project
@@ -25,7 +25,7 @@ tests to run.
 ")
  (depends
   (ocaml (>= 4.03.0))
-  (fmt (>= 0.8.0))
+  (fmt (>= 0.8.6))
   astring
   cmdliner
   uuidm


### PR DESCRIPTION
Fixes https://github.com/mirage/alcotest/issues/218.