### PR TITLE
Upgrade to OCamlformat v0.13.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version = 0.12
+version = 0.13.0
 profile = conventional
 break-infix=fit-or-vertical


### PR DESCRIPTION
- reformats the code to be compliant with OCamlformat v0.13.0
- updates the `.ocamlformat` file accordingly