### PR TITLE
Add a reproduction of a bug with the --verbose flag

### DIFF
--- a/test/e2e/alcotest/passing/dune.inc
+++ b/test/e2e/alcotest/passing/dune.inc
@@ -10,6 +10,7 @@
    list_tests
    quick_only
    quick_only_regex
+   verbose_newlines
  )
  (libraries alcotest)
  (modules
@@ -23,6 +24,7 @@
    list_tests
    quick_only
    quick_only_regex
+   verbose_newlines
  )
 )
 
@@ -275,3 +277,28 @@
  (package alcotest)
  (action
    (diff quick_only_regex.expected quick_only_regex.processed)))
+
+(rule
+ (target verbose_newlines.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:verbose_newlines.exe})
+  )
+ )
+)
+
+(rule
+ (target verbose_newlines.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../../strip_randomness.exe %{dep:verbose_newlines.actual})
+  )
+ )
+)
+
+
+(rule
+ (alias runtest)
+ (package alcotest)
+ (action
+   (diff verbose_newlines.expected verbose_newlines.processed)))

--- a/test/e2e/alcotest/passing/verbose_newlines.expected
+++ b/test/e2e/alcotest/passing/verbose_newlines.expected
@@ -1,0 +1,8 @@
+Testing suite-name.
+This run has ID `<uuid>`.
+ ...                alpha          0   0 newlines.Print inside alpha[OK]                alpha          0   0 newlines.
+ ...                beta           0   1 newline.Print inside beta
+[OK]                beta           0   1 newline.
+ ...                gamma          0   1 newline + long line.Print inside gamma
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, nullam malesuada dictum tortor in venenatis.[OK]                gamma          0   1 newline + long line.
+Test Successful in <test-duration>s. 3 tests run.

--- a/test/e2e/alcotest/passing/verbose_newlines.expected
+++ b/test/e2e/alcotest/passing/verbose_newlines.expected
@@ -5,4 +5,7 @@ This run has ID `<uuid>`.
 [OK]                beta           0   1 newline.
  ...                gamma          0   1 newline + long line.Print inside gamma
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, nullam malesuada dictum tortor in venenatis.[OK]                gamma          0   1 newline + long line.
-Test Successful in <test-duration>s. 3 tests run.
+ ...                delta          0   1 newline + long check.Print inside delta
+[OK]                delta          0   1 newline + long check.
+Test Successful in <test-duration>s. 4 tests run.
+ASSERT Lorem ipsum dolor sit amet, consectetur adipiscing elit, nullam malesuada dictum tortor in venenatis.

--- a/test/e2e/alcotest/passing/verbose_newlines.ml
+++ b/test/e2e/alcotest/passing/verbose_newlines.ml
@@ -26,4 +26,13 @@ let () =
                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, \
                  nullam malesuada dictum tortor in venenatis.");
         ] );
+      ( "delta",
+        [
+          Alcotest.test_case "1 newline + long check" `Quick (fun () ->
+              Format.printf "Print inside delta\n";
+              Alcotest.(check unit)
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, \
+                 nullam malesuada dictum tortor in venenatis."
+                () ());
+        ] );
     ]

--- a/test/e2e/alcotest/passing/verbose_newlines.ml
+++ b/test/e2e/alcotest/passing/verbose_newlines.ml
@@ -1,0 +1,29 @@
+(** Reproduction for https://github.com/mirage/alcotest/issues/225, testing the
+    interaction between `--verbose` and newlines in the test stdout. *)
+
+let () =
+  Alcotest.run ~verbose:true "suite-name"
+    [
+      ( "alpha",
+        [
+          Alcotest.test_case "0 newlines" `Quick (fun () ->
+              Format.printf "Print inside alpha");
+        ] );
+      ( "beta",
+        (* Progressive result reporting is broken for this test, since the
+           carriage return happens on the wrong line. *)
+        [
+          Alcotest.test_case "1 newline" `Quick (fun () ->
+              Format.printf "Print inside beta\n");
+        ] );
+      ( "gamma",
+        [
+          (* Reporting is also broken here. Even worse, some of the test std.out
+             is clipped by the eventual result of the test. *)
+          Alcotest.test_case "1 newline + long line" `Quick (fun () ->
+              Format.printf
+                "Print inside gamma\n\
+                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, \
+                 nullam malesuada dictum tortor in venenatis.");
+        ] );
+    ]


### PR DESCRIPTION
This reproduces the bug detailed in https://github.com/mirage/alcotest/issues/225.

@samoht, this suggests that the `--verbose` flag is not in fact ignored. Can you give a minimal working example of the bug you were experiencing?