### PR TITLE
Test filtering and duplicate-checking logic

### DIFF
--- a/test/e2e/alcotest/failing/dune.inc
+++ b/test/e2e/alcotest/failing/dune.inc
@@ -2,6 +2,7 @@
  (names
    check_basic
    compact
+   duplicate_test_names
    exception_in_test
    invalid_arg_in_test
    tail_errors_limit
@@ -12,6 +13,7 @@
  (modules
    check_basic
    compact
+   duplicate_test_names
    exception_in_test
    invalid_arg_in_test
    tail_errors_limit
@@ -69,6 +71,31 @@
  (package alcotest)
  (action
    (diff compact.expected compact.processed)))
+
+(rule
+ (target duplicate_test_names.actual)
+ (action
+  (with-outputs-to %{target}
+   (run ../../expect_failure.exe %{dep:duplicate_test_names.exe})
+  )
+ )
+)
+
+(rule
+ (target duplicate_test_names.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../../strip_randomness.exe %{dep:duplicate_test_names.actual})
+  )
+ )
+)
+
+
+(rule
+ (alias runtest)
+ (package alcotest)
+ (action
+   (diff duplicate_test_names.expected duplicate_test_names.processed)))
 
 (rule
  (target exception_in_test.actual)

--- a/test/e2e/alcotest/failing/dune.inc
+++ b/test/e2e/alcotest/failing/dune.inc
@@ -4,6 +4,7 @@
    compact
    duplicate_test_names
    exception_in_test
+   filter_all_tests
    invalid_arg_in_test
    tail_errors_limit
    tail_errors_unlimited
@@ -15,6 +16,7 @@
    compact
    duplicate_test_names
    exception_in_test
+   filter_all_tests
    invalid_arg_in_test
    tail_errors_limit
    tail_errors_unlimited
@@ -121,6 +123,31 @@
  (package alcotest)
  (action
    (diff exception_in_test.expected exception_in_test.processed)))
+
+(rule
+ (target filter_all_tests.actual)
+ (action
+  (with-outputs-to %{target}
+   (run ../../expect_failure.exe %{dep:filter_all_tests.exe} test bar 1)
+  )
+ )
+)
+
+(rule
+ (target filter_all_tests.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../../strip_randomness.exe %{dep:filter_all_tests.actual})
+  )
+ )
+)
+
+
+(rule
+ (alias runtest)
+ (package alcotest)
+ (action
+   (diff filter_all_tests.expected filter_all_tests.processed)))
 
 (rule
  (target invalid_arg_in_test.actual)

--- a/test/e2e/alcotest/failing/duplicate_test_names.expected
+++ b/test/e2e/alcotest/failing/duplicate_test_names.expected
@@ -1,0 +1,4 @@
+duplicate_test_names.exe: internal error, uncaught exception:
+                          Alcotest__Core.Registration_error("Duplicate test name: duped")
+                          
+Fatal error: exception Alcotest__Core.Make(M).Test_error

--- a/test/e2e/alcotest/failing/duplicate_test_names.ml
+++ b/test/e2e/alcotest/failing/duplicate_test_names.ml
@@ -1,0 +1,8 @@
+(** Ensure that suites with duplicate test names are rejected. *)
+
+let () =
+  Alcotest.run "suite-with-duplicate-names"
+    [
+      ("duped", [ Alcotest.test_case "1" `Quick (fun () -> assert false) ]);
+      ("duped", [ Alcotest.test_case "2" `Quick (fun () -> assert false) ]);
+    ]

--- a/test/e2e/alcotest/failing/filter_all_tests.expected
+++ b/test/e2e/alcotest/failing/filter_all_tests.expected
@@ -1,0 +1,3 @@
+Invalid request (no tests to run, filter skipped everything)!
+Testing suite-with-duplicate-names.
+This run has ID `<uuid>`.

--- a/test/e2e/alcotest/failing/filter_all_tests.ml
+++ b/test/e2e/alcotest/failing/filter_all_tests.ml
@@ -1,0 +1,8 @@
+(** Ensure that filters which eliminate all tests are rejected. *)
+
+let () =
+  Alcotest.run "suite-with-duplicate-names"
+    [
+      ("foo", [ Alcotest.test_case "1" `Quick (fun () -> assert false) ]);
+      ("bar", [ Alcotest.test_case "2" `Quick (fun () -> assert false) ]);
+    ]

--- a/test/e2e/alcotest/failing/filter_all_tests.opts
+++ b/test/e2e/alcotest/failing/filter_all_tests.opts
@@ -1,0 +1,1 @@
+test bar 1


### PR DESCRIPTION
This adds two tests of edge cases that were previously untested:
- a filter is passed via `test [NAME_REGEX] [TESTCASES]` that filters out all tests
- the suite contains duplicate test names (see https://github.com/mirage/alcotest/pull/176)