### PR TITLE
Fix interleaving of ASSERTs with other console output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ### Unreleased
 
 - Fix handling of CLI options for `Alcotest_{async,lwt}.run`. (#222, @CraigFe)
+- Fix interleaving of ASSERT outputs with the other test code, and ensure that
+  it is correctly captured in log files. (#215 #228, @icristescu @CraigFe)
 
 ### 1.0.1 (2020-02-12)
 

--- a/src/alcotest/alcotest.ml
+++ b/src/alcotest/alcotest.ml
@@ -140,7 +140,9 @@ let reject (type a) =
   (module M : TESTABLE with type t = M.t)
 
 let show_assert msg =
-  Format.eprintf "%a %s\n" Fmt.(styled `Yellow string) "ASSERT" msg
+  (* Flush any test stdout preceding the assert *)
+  Fmt.(flush stdout) ();
+  Format.eprintf "%a %s\n%!" Fmt.(styled `Yellow string) "ASSERT" msg
 
 let check_err fmt =
   Format.ksprintf (fun err -> raise (Core.Check_error err)) fmt

--- a/src/alcotest/alcotest.ml
+++ b/src/alcotest/alcotest.ml
@@ -19,6 +19,7 @@ module Cli = Cli
 module Monad = Monad
 module T = Cli.Make (Monad.Identity)
 include T
+open Utils
 
 module type TESTABLE = sig
   type t

--- a/src/alcotest/alcotest.ml
+++ b/src/alcotest/alcotest.ml
@@ -140,8 +140,7 @@ let reject (type a) =
   (module M : TESTABLE with type t = M.t)
 
 let show_assert msg =
-  (* Flush any test stdout preceding the assert *)
-  Fmt.(flush stdout) ();
+  Fmt.(flush stdout) () (* Flush any test stdout preceding the assert *);
   Format.eprintf "%a %s\n%!" Fmt.(styled `Yellow string) "ASSERT" msg
 
 let check_err fmt =

--- a/src/alcotest/core.ml
+++ b/src/alcotest/core.ml
@@ -324,8 +324,8 @@ module Make (M : Monad.S) = struct
     let open Suite in
     let test = suite.fn in
     let pp_event = pp_event t in
-    M.return () >>= fun () ->
     pp_event Fmt.stdout (`Start suite.path);
+    Fmt.(flush stdout) () (* Show event before any test stderr *);
     test args >|= fun result ->
     (* Store errors *)
     let () =
@@ -342,14 +342,18 @@ module Make (M : Monad.S) = struct
       in
       t.errors <- error @ t.errors
     in
+    (* Show any remaining test output before the event *)
+    Fmt.(flush stdout ());
+    Fmt.(flush stderr ());
     pp_event Fmt.stdout (`Result (suite.path, result));
     result
 
   let perform_tests t tests args = M.List.map_s (perform_test t args) tests
 
   let with_redirect file fn =
-    flush stdout;
-    flush stderr;
+    M.return () >>= fun () ->
+    Fmt.(flush stdout) ();
+    Fmt.(flush stderr) ();
     let fd_stdout = Unix.descr_of_out_channel stdout in
     let fd_stderr = Unix.descr_of_out_channel stderr in
     let fd_old_stdout = Unix.dup fd_stdout in
@@ -359,8 +363,8 @@ module Make (M : Monad.S) = struct
     Unix.dup2 fd_file fd_stderr;
     Unix.close fd_file;
     (try fn () >|= fun o -> `Ok o with e -> M.return @@ `Error e) >|= fun r ->
-    flush stdout;
-    flush stderr;
+    Fmt.(flush stdout ());
+    Fmt.(flush stderr ());
     Unix.dup2 fd_old_stdout fd_stdout;
     Unix.dup2 fd_old_stderr fd_stderr;
     Unix.close fd_old_stdout;

--- a/src/alcotest/core.ml
+++ b/src/alcotest/core.ml
@@ -324,6 +324,7 @@ module Make (M : Monad.S) = struct
     let open Suite in
     let test = suite.fn in
     let pp_event = pp_event t in
+    M.return () >>= fun () ->
     pp_event Fmt.stdout (`Start suite.path);
     Fmt.(flush stdout) () (* Show event before any test stderr *);
     test args >|= fun result ->
@@ -524,7 +525,9 @@ module Make (M : Monad.S) = struct
         Fmt.(pf stderr) "%a\n" Fmt.(list string) (List.rev error_acc);
         exit 1
     | Ok t -> (
-        ( Fmt.(pf stdout) "Testing %a.\n" bold_s name;
+        ( (* Only print inside the concurrency monad *)
+          M.return () >>= fun () ->
+          Fmt.(pf stdout) "Testing %a.\n" bold_s name;
           Fmt.(pf stdout) "This run has ID `%s`.\n" run_id;
           run_tests ?filter t () args )
         >|= fun test_failures ->

--- a/src/alcotest/core.ml
+++ b/src/alcotest/core.ml
@@ -324,6 +324,7 @@ module Make (M : Monad.S) = struct
     let open Suite in
     let test = suite.fn in
     let pp_event = pp_event t in
+    M.return () >>= fun () ->
     pp_event Fmt.stdout (`Start suite.path);
     test args >|= fun result ->
     (* Store errors *)

--- a/src/alcotest/utils.ml
+++ b/src/alcotest/utils.ml
@@ -54,3 +54,14 @@ module Unix = struct
     | dl :: xs when is_win_drive_letter dl -> mk dl xs
     | xs -> mk "." xs
 end
+
+module Fmt = struct
+  [@@@warning "-32"]
+
+  (* Re-implement [flush] for pre-0.8.6 compatibility *)
+  let flush ppf _ = Format.pp_print_flush ppf ()
+
+  [@@@warning "+32"]
+
+  include Fmt
+end

--- a/src/alcotest/utils.mli
+++ b/src/alcotest/utils.mli
@@ -17,3 +17,9 @@ module Unix : sig
 
   val mkdir_p : string -> file_perm -> unit
 end
+
+module Fmt : sig
+  include module type of Fmt
+
+  val flush : 'a t
+end

--- a/test/e2e/alcotest/failing/check_basic.expected
+++ b/test/e2e/alcotest/failing/check_basic.expected
@@ -14,6 +14,7 @@ This run has ID `<uuid>`.
  ...                different composite          4   pair.[FAIL]              different composite          4   pair.
 -- different basic.000 [bool.] Failed --
 in `<build-context>/_build/_tests/<uuid>/different basic.000.output`:
+ASSERT bool
 [failure] Error bool: expecting
 true, got
 false.

--- a/test/e2e/alcotest/failing/tail_errors_limit.expected
+++ b/test/e2e/alcotest/failing/tail_errors_limit.expected
@@ -3,8 +3,7 @@ This run has ID `<uuid>`.
  ...                failing          0   test.[ERROR]             failing          0   test.
 -- failing.000 [test.] Failed --
 in `<build-context>/_build/_tests/<uuid>/failing.000.output`:
-... (omitting 91 lines)
-output line 92
+... (omitting 92 lines)
 output line 93
 output line 94
 output line 95
@@ -13,8 +12,8 @@ output line 97
 output line 98
 output line 99
 output line 100
-Test error: Error Logs above should be 10 lines long (omitting 91)..
+ASSERT Logs should be 10 lines long, including this line (omitting 92).
+Test error: Error Logs should be 10 lines long, including this line (omitting 92)..
 
 The full test results are available in `<build-context>/_build/_tests/<uuid>`.
 1 error! in <test-duration>s. 1 test run.
-ASSERT Logs above should be 10 lines long (omitting 91).

--- a/test/e2e/alcotest/failing/tail_errors_limit.ml
+++ b/test/e2e/alcotest/failing/tail_errors_limit.ml
@@ -2,7 +2,8 @@ let test_error_output () =
   for i = 1 to 100 do
     Printf.printf "output line %i\n" i
   done;
-  Alcotest.fail "Logs above should be 10 lines long (omitting 91)."
+  Alcotest.fail
+    "Logs should be 10 lines long, including this line (omitting 92)."
 
 let () =
   let open Alcotest in

--- a/test/e2e/alcotest/failing/tail_errors_unlimited.expected
+++ b/test/e2e/alcotest/failing/tail_errors_unlimited.expected
@@ -103,8 +103,8 @@ output line 97
 output line 98
 output line 99
 output line 100
+ASSERT Logs above should be 101 lines long.
 Test error: Error Logs above should be 101 lines long..
 
 The full test results are available in `<build-context>/_build/_tests/<uuid>`.
 1 error! in <test-duration>s. 1 test run.
-ASSERT Logs above should be 101 lines long.

--- a/test/e2e/alcotest/passing/assert_and_verbose.expected
+++ b/test/e2e/alcotest/passing/assert_and_verbose.expected
@@ -1,0 +1,19 @@
+Testing assert-and-verbose.
+This run has ID `<uuid>`.
+ ...                alpha          0   check → stdout.
+alpha-0 standard out
+ASSERT alpha-0 check
+[OK]                alpha          0   check → stdout.
+ ...                alpha          1   stdout → check.
+alpha-1 standard out
+ASSERT alpha-1 check
+[OK]                alpha          1   stdout → check.
+ ...                alpha          2   check → stderr.ASSERT alpha-2 check
+alpha-2 standard error
+[OK]                alpha          2   check → stderr.
+ ...                beta           0   stdout → check → stderr.
+beta-0 standard out
+ASSERT beta-0 check
+beta-0 standard error
+[OK]                beta           0   stdout → check → stderr.
+Test Successful in <test-duration>s. 4 tests run.

--- a/test/e2e/alcotest/passing/assert_and_verbose.expected
+++ b/test/e2e/alcotest/passing/assert_and_verbose.expected
@@ -1,8 +1,7 @@
 Testing assert-and-verbose.
 This run has ID `<uuid>`.
- ...                alpha          0   check → stdout.
+ ...                alpha          0   check → stdout.ASSERT alpha-0 check
 alpha-0 standard out
-ASSERT alpha-0 check
 [OK]                alpha          0   check → stdout.
  ...                alpha          1   stdout → check.
 alpha-1 standard out

--- a/test/e2e/alcotest/passing/assert_and_verbose.ml
+++ b/test/e2e/alcotest/passing/assert_and_verbose.ml
@@ -8,7 +8,7 @@ let () =
         [
           Alcotest.test_case "check → stdout" `Quick (fun () ->
               Alcotest.(check unit) "alpha-0 check" () ();
-              Format.printf "\nalpha-0 standard out\n");
+              Format.printf "alpha-0 standard out\n");
           Alcotest.test_case "stdout → check" `Quick (fun () ->
               Format.printf "\nalpha-1 standard out\n";
               Alcotest.(check unit) "alpha-1 check" () ());

--- a/test/e2e/alcotest/passing/assert_and_verbose.ml
+++ b/test/e2e/alcotest/passing/assert_and_verbose.ml
@@ -1,0 +1,26 @@
+(** Test the interaction between ASSERT prints and the `--verbose` option. *)
+
+let () =
+  let open Alcotest in
+  run ~verbose:true "assert-and-verbose"
+    [
+      ( "alpha",
+        [
+          Alcotest.test_case "check → stdout" `Quick (fun () ->
+              Alcotest.(check unit) "alpha-0 check" () ();
+              Format.printf "\nalpha-0 standard out\n");
+          Alcotest.test_case "stdout → check" `Quick (fun () ->
+              Format.printf "\nalpha-1 standard out\n";
+              Alcotest.(check unit) "alpha-1 check" () ());
+          Alcotest.test_case "check → stderr" `Quick (fun () ->
+              Alcotest.(check unit) "alpha-2 check" () ();
+              Format.eprintf "alpha-2 standard error\n");
+        ] );
+      ( "beta",
+        [
+          Alcotest.test_case "stdout → check → stderr" `Quick (fun () ->
+              Format.printf "\nbeta-0 standard out\n";
+              Alcotest.(check unit) "beta-0 check" () ();
+              Format.eprintf "beta-0 standard error\n");
+        ] );
+    ]

--- a/test/e2e/alcotest/passing/assert_not_printed.expected
+++ b/test/e2e/alcotest/passing/assert_not_printed.expected
@@ -1,7 +1,7 @@
 Testing assert-not-printed.
 This run has ID `<uuid>`.
- ...                alpha          0   tc0.[OK]                alpha          0   tc0.
- ...                alpha          1   tc1.[OK]                alpha          1   tc1.
- ...                beta           0   tc0.[OK]                beta           0   tc0.
+ ...                alpha          0   0.[OK]                alpha          0   0.
+ ...                alpha          1   1.[OK]                alpha          1   1.
+ ...                beta           0   2.[OK]                beta           0   2.
 The full test results are available in `<build-context>/_build/_tests/<uuid>`.
 Test Successful in <test-duration>s. 3 tests run.

--- a/test/e2e/alcotest/passing/assert_not_printed.expected
+++ b/test/e2e/alcotest/passing/assert_not_printed.expected
@@ -5,6 +5,3 @@ This run has ID `<uuid>`.
  ...                beta           0   tc0.[OK]                beta           0   tc0.
 The full test results are available in `<build-context>/_build/_tests/<uuid>`.
 Test Successful in <test-duration>s. 3 tests run.
-ASSERT alpha-0 check
-ASSERT alpha-1 check
-ASSERT beta-0 check

--- a/test/e2e/alcotest/passing/assert_not_printed.expected
+++ b/test/e2e/alcotest/passing/assert_not_printed.expected
@@ -1,0 +1,10 @@
+Testing assert-not-printed.
+This run has ID `<uuid>`.
+ ...                alpha          0   tc0.[OK]                alpha          0   tc0.
+ ...                alpha          1   tc1.[OK]                alpha          1   tc1.
+ ...                beta           0   tc0.[OK]                beta           0   tc0.
+The full test results are available in `<build-context>/_build/_tests/<uuid>`.
+Test Successful in <test-duration>s. 3 tests run.
+ASSERT alpha-0 check
+ASSERT alpha-1 check
+ASSERT beta-0 check

--- a/test/e2e/alcotest/passing/assert_not_printed.ml
+++ b/test/e2e/alcotest/passing/assert_not_printed.ml
@@ -1,21 +1,24 @@
-(** Reproduction for the issue for which
-    https://github.com/mirage/alcotest/pull/215 is an attempted fix. ASSERT
-    lines should only be printed if either `--verbose` is set or the tests fail. *)
+(** Regression test for an issue in which stderr was not captured into the test
+    logs due to Format buffers not being flushed. See
+    https://github.com/mirage/alcotest/pull/228 for details. *)
 
 let () =
   let open Alcotest in
+  let s tc = tc ^ ": SHOULD NOT BE PRINTED" in
   run "assert-not-printed"
     [
       ( "alpha",
         [
-          Alcotest.test_case "tc0" `Quick (fun () ->
-              Alcotest.(check unit) "alpha-0 check" () ());
-          Alcotest.test_case "tc1" `Quick (fun () ->
-              Alcotest.(check unit) "alpha-1 check" () ());
+          Alcotest.test_case "0" `Quick (fun () ->
+              Alcotest.(check unit) (s "0") () ());
+          Alcotest.test_case "1" `Quick (fun () ->
+              Format.eprintf "%s" (s "1");
+              Alcotest.(check unit) (s "1") () ());
         ] );
       ( "beta",
         [
-          Alcotest.test_case "tc0" `Quick (fun () ->
-              Alcotest.(check unit) "beta-0 check" () ());
+          Alcotest.test_case "2" `Quick (fun () ->
+              Alcotest.(check unit) "2" () ();
+              Format.eprintf "%s" (s "2"));
         ] );
     ]

--- a/test/e2e/alcotest/passing/assert_not_printed.ml
+++ b/test/e2e/alcotest/passing/assert_not_printed.ml
@@ -1,0 +1,21 @@
+(** Reproduction for the issue for which
+    https://github.com/mirage/alcotest/pull/215 is an attempted fix. ASSERT
+    lines should only be printed if either `--verbose` is set or the tests fail. *)
+
+let () =
+  let open Alcotest in
+  run "assert-not-printed"
+    [
+      ( "alpha",
+        [
+          Alcotest.test_case "tc0" `Quick (fun () ->
+              Alcotest.(check unit) "alpha-0 check" () ());
+          Alcotest.test_case "tc1" `Quick (fun () ->
+              Alcotest.(check unit) "alpha-1 check" () ());
+        ] );
+      ( "beta",
+        [
+          Alcotest.test_case "tc0" `Quick (fun () ->
+              Alcotest.(check unit) "beta-0 check" () ());
+        ] );
+    ]

--- a/test/e2e/alcotest/passing/dune.inc
+++ b/test/e2e/alcotest/passing/dune.inc
@@ -10,6 +10,7 @@
    filter_name_regex
    json_output
    list_tests
+   only_monadic_effects
    quick_only
    quick_only_regex
  )
@@ -25,6 +26,7 @@
    filter_name_regex
    json_output
    list_tests
+   only_monadic_effects
    quick_only
    quick_only_regex
  )
@@ -279,6 +281,31 @@
  (package alcotest)
  (action
    (diff list_tests.expected list_tests.processed)))
+
+(rule
+ (target only_monadic_effects.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:only_monadic_effects.exe})
+  )
+ )
+)
+
+(rule
+ (target only_monadic_effects.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../../strip_randomness.exe %{dep:only_monadic_effects.actual})
+  )
+ )
+)
+
+
+(rule
+ (alias runtest)
+ (package alcotest)
+ (action
+   (diff only_monadic_effects.expected only_monadic_effects.processed)))
 
 (rule
  (target quick_only.actual)

--- a/test/e2e/alcotest/passing/dune.inc
+++ b/test/e2e/alcotest/passing/dune.inc
@@ -2,6 +2,7 @@
  (names
    and_exit_false
    and_exit_true
+   assert_and_verbose
    assert_not_printed
    basic
    check_basic
@@ -16,6 +17,7 @@
  (modules
    and_exit_false
    and_exit_true
+   assert_and_verbose
    assert_not_printed
    basic
    check_basic
@@ -77,6 +79,31 @@
  (package alcotest)
  (action
    (diff and_exit_true.expected and_exit_true.processed)))
+
+(rule
+ (target assert_and_verbose.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:assert_and_verbose.exe})
+  )
+ )
+)
+
+(rule
+ (target assert_and_verbose.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../../strip_randomness.exe %{dep:assert_and_verbose.actual})
+  )
+ )
+)
+
+
+(rule
+ (alias runtest)
+ (package alcotest)
+ (action
+   (diff assert_and_verbose.expected assert_and_verbose.processed)))
 
 (rule
  (target assert_not_printed.actual)

--- a/test/e2e/alcotest/passing/dune.inc
+++ b/test/e2e/alcotest/passing/dune.inc
@@ -2,6 +2,7 @@
  (names
    and_exit_false
    and_exit_true
+   assert_not_printed
    basic
    check_basic
    filter_name
@@ -15,6 +16,7 @@
  (modules
    and_exit_false
    and_exit_true
+   assert_not_printed
    basic
    check_basic
    filter_name
@@ -75,6 +77,31 @@
  (package alcotest)
  (action
    (diff and_exit_true.expected and_exit_true.processed)))
+
+(rule
+ (target assert_not_printed.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:assert_not_printed.exe})
+  )
+ )
+)
+
+(rule
+ (target assert_not_printed.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../../strip_randomness.exe %{dep:assert_not_printed.actual})
+  )
+ )
+)
+
+
+(rule
+ (alias runtest)
+ (package alcotest)
+ (action
+   (diff assert_not_printed.expected assert_not_printed.processed)))
 
 (rule
  (target basic.actual)

--- a/test/e2e/alcotest/passing/only_monadic_effects.expected
+++ b/test/e2e/alcotest/passing/only_monadic_effects.expected
@@ -1,0 +1,5 @@
+Testing event_ordering.
+This run has ID `<uuid>`.
+ ...                alpha          0   check + stdout + stderr.ASSERT SHOULD NOT BE PRINTED
+stdout: SHOULD NOT BE PRINTED
+stderr: SHOULD NOT BE PRINTED

--- a/test/e2e/alcotest/passing/only_monadic_effects.expected
+++ b/test/e2e/alcotest/passing/only_monadic_effects.expected
@@ -1,5 +1,0 @@
-Testing event_ordering.
-This run has ID `<uuid>`.
- ...                alpha          0   check + stdout + stderr.ASSERT SHOULD NOT BE PRINTED
-stdout: SHOULD NOT BE PRINTED
-stderr: SHOULD NOT BE PRINTED

--- a/test/e2e/alcotest/passing/only_monadic_effects.ml
+++ b/test/e2e/alcotest/passing/only_monadic_effects.ml
@@ -8,7 +8,11 @@
 
     This is tested by building a runner over the [Terminal] monad, which reduces
     to [()] immediately on evaluation and so discovers any effects in the
-    evaluation of the bottom-most value in the computation. *)
+    evaluation of the bottom-most value in the computation.
+
+    This is a regression test for a bug in which test effects were partially
+    observable during evaluation of the computation. See
+    https://github.com/mirage/alcotest/pull/228 for more details. *)
 
 module Terminal : Alcotest.Monad.S = struct
   type 'a t = unit

--- a/test/e2e/alcotest/passing/only_monadic_effects.ml
+++ b/test/e2e/alcotest/passing/only_monadic_effects.ml
@@ -1,0 +1,41 @@
+(** Ensures that {!Alcotest.run} does not print when evaluated at monadic type
+    (until the resulting computation is explicitly run). We require that effects
+    introduced by tests (whether during evaluation {i or} during running the
+    computation) are not partially observable during application of
+    {!Alcotest.run}. This is because such behaviour could be relied upon as part
+    of the public API, when in fact it is dependent on internal implementation
+    details.
+
+    This is tested by building a runner over the [Terminal] monad, which reduces
+    to [()] immediately on evaluation and so discovers any effects in the
+    evaluation of the bottom-most value in the computation. *)
+
+module Terminal : Alcotest.Monad.S = struct
+  type 'a t = unit
+
+  let return _ = ()
+
+  let bind () _ = ()
+
+  let catch f on_error = match f () with x -> x | exception ex -> on_error ex
+end
+
+module Runner = Alcotest.Core.Make (Terminal)
+
+let () =
+  let (_ : unit Terminal.t) =
+    Runner.run ~verbose:true "event_ordering"
+      [
+        ( "alpha",
+          [
+            Runner.test_case "check + stdout + stderr" `Quick (fun () ->
+                Alcotest.(check unit) "SHOULD NOT BE PRINTED" () ();
+                Format.printf "stdout: SHOULD NOT BE PRINTED\n";
+                Format.eprintf "stderr: SHOULD NOT BE PRINTED\n";
+                assert false);
+          ] );
+      ]
+  in
+  Format.pp_print_flush Format.std_formatter ();
+  Format.pp_print_flush Format.err_formatter ();
+  ()


### PR DESCRIPTION
... by adding flushes in various places, being sure to flush internal `Format` buffers as well as those of the output channels.

This has the side-effect of ensuring that all `ASSERT` lines are captured in log files (when `--verbose` is not passed), which was previously not the case because of `Format` buffers being flushed after the redirection had stopped.

This supersedes the fix in https://github.com/mirage/alcotest/pull/215, which I now believe is taking the wrong approach: i.e. we should always print `ASSERTS` regardless of test failure, but should also be sure to capture them in the test logs correctly. 