### PR TITLE
Refactor and clarify processing of CLI flags

### DIFF
--- a/test/e2e/alcotest/passing/cli_verbose.expected
+++ b/test/e2e/alcotest/passing/cli_verbose.expected
@@ -1,0 +1,5 @@
+Testing cli_verbose.
+This run has ID `<uuid>`.
+ ...                alpha          0   0.SHOULD APPEAR IN TEST OUTPUT
+[OK]                alpha          0   0.
+Test Successful in <test-duration>s. 1 test run.

--- a/test/e2e/alcotest/passing/cli_verbose.ml
+++ b/test/e2e/alcotest/passing/cli_verbose.ml
@@ -1,0 +1,13 @@
+(** Ensures that the `--verbose` flag is passed from the CLI. *)
+
+let () =
+  let open Alcotest in
+  run ~verbose:false (* CLI flag should take priority over this option *)
+    "cli_verbose"
+    [
+      ( "alpha",
+        [
+          test_case "0" `Quick (fun () ->
+              Format.printf "SHOULD APPEAR IN TEST OUTPUT\n");
+        ] );
+    ]

--- a/test/e2e/alcotest/passing/cli_verbose.opts
+++ b/test/e2e/alcotest/passing/cli_verbose.opts
@@ -1,0 +1,1 @@
+--verbose

--- a/test/e2e/alcotest/passing/dune.inc
+++ b/test/e2e/alcotest/passing/dune.inc
@@ -4,6 +4,7 @@
    and_exit_true
    basic
    check_basic
+   cli_verbose
    filter_name
    filter_name_regex
    json_output
@@ -17,6 +18,7 @@
    and_exit_true
    basic
    check_basic
+   cli_verbose
    filter_name
    filter_name_regex
    json_output
@@ -125,6 +127,31 @@
  (package alcotest)
  (action
    (diff check_basic.expected check_basic.processed)))
+
+(rule
+ (target cli_verbose.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:cli_verbose.exe} --verbose)
+  )
+ )
+)
+
+(rule
+ (target cli_verbose.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../../strip_randomness.exe %{dep:cli_verbose.actual})
+  )
+ )
+)
+
+
+(rule
+ (alias runtest)
+ (package alcotest)
+ (action
+   (diff cli_verbose.expected cli_verbose.processed)))
 
 (rule
  (target filter_name.actual)


### PR DESCRIPTION
This cleans up the option handling logic and documents the precedence order that is expected to hold. This avoids setting default values for e.g.  `--verbose` in both `core.ml` and `cli.ml`.

Also adds a test verifying that the `--verbose` CLI flag takes priority over the compile-time parameter.