### PR TITLE
Improve the documentation layout

### DIFF
--- a/src/alcotest/alcotest.mli
+++ b/src/alcotest/alcotest.mli
@@ -27,12 +27,6 @@
 
     {e Release %%VERSION%%} *)
 
-module Core : module type of Core
-
-module Cli : module type of Cli
-
-module Monad : module type of Monad
-
 include Cli.S with type return = unit
 
 (** {2 Assert functions} *)
@@ -129,3 +123,21 @@ val neg : 'a testable -> 'a testable
 
 val check_raises : string -> exn -> (unit -> unit) -> unit
 (** Check that an exception is raised. *)
+
+(** {1 Monadic test runners} *)
+
+(** These modules provide the ability to run tests inside a concurrency monad:
+    that is, to sequence test cases of type ['a -> unit m] into a computation of
+    type ['a -> unit m] (for some concurrency monad [m]) with can then be
+    scheduled in a main event loop. For tests using [Lwt.t] or
+    [Async_kernel.Deferred.t], use the [Alcotest_lwt] and [Alcotest_async]
+    packages directly. *)
+
+module Core : module type of Core
+(** Defines monadic test runners {i without} command-line interfaces. *)
+
+module Cli : module type of Cli
+(** Wraps {!Core} to provide a command-line interface. *)
+
+module Monad : module type of Monad
+(** Monad signatures for use with {!Core} and {!Cli}. *)

--- a/src/alcotest/cli.ml
+++ b/src/alcotest/cli.ml
@@ -34,6 +34,8 @@ module type S = sig
     with_options
 end
 
+module type MAKER = functor (M : Monad.S) -> S with type return = unit M.t
+
 module Make (M : Monad.S) : S with type return = unit M.t = struct
   module C = Core.Make (M)
   include C

--- a/src/alcotest/cli.mli
+++ b/src/alcotest/cli.mli
@@ -25,6 +25,7 @@
 
 module type S = sig
   include Core.S
+  (** @inline *)
 
   val run :
     (?argv:string array -> string -> unit test list -> return) with_options
@@ -56,5 +57,7 @@ module type S = sig
       [Cdmliner] term [a]: this is useful to configure the test behaviors using
       the CLI. *)
 end
+
+module type MAKER = functor (M : Monad.S) -> S with type return = unit M.t
 
 module Make (M : Monad.S) : S with type return = unit M.t

--- a/src/alcotest/core.ml
+++ b/src/alcotest/core.ml
@@ -61,7 +61,9 @@ module type S = sig
   val run_with_args : (string -> 'a -> 'a test list -> return) with_options
 end
 
-module Make (M : Monad.S) = struct
+module type MAKER = functor (M : Monad.S) -> S with type return = unit M.t
+
+module Make (M : Monad.S) : S with type return = unit M.t = struct
   module M = Monad.Extend (M)
   include M.Infix
 


### PR DESCRIPTION
Recent features have made the docs a bit too complex for newcomers (particularly monad parameterisation). This undoes the damage by reordering to present simplest concepts first and adding some explanation here and there.