### PR TITLE
Upgrade to OCamlformat v0.14.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version = 0.13.0
+version = 0.14.0
 break-infix=fit-or-vertical
 parse-docstrings

--- a/src/alcotest/alcotest.mli
+++ b/src/alcotest/alcotest.mli
@@ -33,8 +33,8 @@ include Cli.S with type return = unit
 
 (** [TESTABLE] provides an abstract description for testable values. *)
 module type TESTABLE = sig
-  type t
   (** The type to test. *)
+  type t
 
   val pp : t Fmt.t
   (** A way to pretty-print the value. *)
@@ -43,8 +43,8 @@ module type TESTABLE = sig
   (** Test for equality between two values. *)
 end
 
-type 'a testable = (module TESTABLE with type t = 'a)
 (** The type for testable values. *)
+type 'a testable = (module TESTABLE with type t = 'a)
 
 val testable : 'a Fmt.t -> ('a -> 'a -> bool) -> 'a testable
 (** [testable pp eq] is a new {!testable} with the pretty-printer [pp] and
@@ -133,11 +133,11 @@ val check_raises : string -> exn -> (unit -> unit) -> unit
     [Async_kernel.Deferred.t], use the [Alcotest_lwt] and [Alcotest_async]
     packages directly. *)
 
-module Core : module type of Core
 (** Defines monadic test runners {i without} command-line interfaces. *)
+module Core : module type of Core
 
-module Cli : module type of Cli
 (** Wraps {!Core} to provide a command-line interface. *)
+module Cli : module type of Cli
 
-module Monad : module type of Monad
 (** Monad signatures for use with {!Core} and {!Cli}. *)
+module Monad : module type of Monad

--- a/src/alcotest/cli.mli
+++ b/src/alcotest/cli.mli
@@ -24,8 +24,8 @@
     - all of the regular options to Alcotest.run can be set via CLI flags. *)
 
 module type S = sig
-  include Core.S
   (** @inline *)
+  include Core.S
 
   val run :
     (?argv:string array -> string -> unit test list -> return) with_options

--- a/src/alcotest/core.mli
+++ b/src/alcotest/core.mli
@@ -19,46 +19,35 @@ exception Check_error of string
 module IntSet : Set.S with type elt = int
 
 module type S = sig
-  type return
   (** The return type of each test case run by Alcotest. For the standard
       {!Alcotest} module, [return = unit]. The concurrent backends
       [Alcotest_lwt] and [Alcotest_async] set [return = unit Lwt.t] and
       [return = Async_kernel.Deferred.t] respectively. *)
+  type return
 
-  type speed_level = [ `Quick | `Slow ]
   (** Speed level of a test. Tests marked as [`Quick] are always run. Tests
       marked as [`Slow] are skipped when the `-q` flag is passed. *)
+  type speed_level = [ `Quick | `Slow ]
 
-  type 'a test_case = string * speed_level * ('a -> return)
   (** A test case is a UTF-8 encoded documentation string, a speed level and a
       function to execute. Typically, the testing function calls the helper
       functions provided below (such as [check] and [fail]). *)
+  type 'a test_case = string * speed_level * ('a -> return)
 
-  exception Test_error
   (** The exception return by {!run} in case of errors. *)
+  exception Test_error
 
   val test_case : string -> speed_level -> ('a -> return) -> 'a test_case
   (** [test_case n s f] is the test case [n] running at speed [s] using the
       function [f]. *)
 
-  type 'a test = string * 'a test_case list
   (** A test is a US-ASCII encoded name and a list of test cases. The name can
       be used for filtering which tests to run on the CLI *)
+  type 'a test = string * 'a test_case list
 
   val list_tests : 'a test list -> return
   (** Print all of the test cases in a human-readable form *)
 
-  type 'a with_options =
-    ?and_exit:bool ->
-    ?verbose:bool ->
-    ?compact:bool ->
-    ?tail_errors:[ `Unlimited | `Limit of int ] ->
-    ?quick_only:bool ->
-    ?show_errors:bool ->
-    ?json:bool ->
-    ?filter:Re.re option * IntSet.t option ->
-    ?log_dir:string ->
-    'a
   (** The various options taken by the tests runners {!run} and
       {!run_with_args}:
 
@@ -76,6 +65,17 @@ module type S = sig
         format.
       - [log_dir] (default ["$PWD/_build/_tests/"]). The directory in which to
         log the output of the tests (if [verbose] is not set). *)
+  type 'a with_options =
+    ?and_exit:bool ->
+    ?verbose:bool ->
+    ?compact:bool ->
+    ?tail_errors:[ `Unlimited | `Limit of int ] ->
+    ?quick_only:bool ->
+    ?show_errors:bool ->
+    ?json:bool ->
+    ?filter:Re.re option * IntSet.t option ->
+    ?log_dir:string ->
+    'a
 
   val run : (string -> unit test list -> return) with_options
 
@@ -84,8 +84,8 @@ end
 
 module type MAKER = functor (M : Monad.S) -> S with type return = unit M.t
 
-module Make : MAKER
 (** Functor for building a tester that sequences tests of type
     [('a -> unit M.t)] within a given concurrency monad [M.t]. The [run] and
     [run_with_args] functions must be scheduled in a global event loop. Intended
     for use by the {!Alcotest_lwt} and {!Alcotest_async} backends. *)
+module Make : MAKER


### PR DESCRIPTION
- reformats the code to be compliant with OCamlformat v0.14.0
- updates the `.ocamlformat` file accordingly