### PR TITLE
Upgrade to OCamlformat v0.14.1

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version = 0.13.0
+version = 0.14.1
 break-infix=fit-or-vertical
 parse-docstrings


### PR DESCRIPTION
- reformats the code to be compliant with OCamlformat v0.14.1
- updates the `.ocamlformat` file accordingly