### PR TITLE
Use coloured output by default when running INSIDE_DUNE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 matrix:
   include:
     - os: linux
-      env: OCAML_VERSION=4.04 PACKAGE="alcotest-lwt"
+      env: OCAML_VERSION=4.05 PACKAGE="alcotest-lwt"
     - os: linux
       env: OCAML_VERSION=4.05 PACKAGE="alcotest-async"
     - os: linux

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,17 @@
 
 - Add a testable for the `bytes` type. (#253, @mefyl)
 
+- Default to `--color=always` when running inside Dune (#242, @CraigFe). The
+  value can be overridden by setting the `ALCOTEST_COLOR` variable in a `dune`
+  file, for example:
+
+```dune
+(env
+ (_
+  (env-vars
+   (ALCOTEST_COLOR auto))))
+```
+
 ### 1.1.0 (2020-04-03)
 
 - Fix handling of CLI options for `Alcotest_{async,lwt}.run`. (#222, @CraigFe)

--- a/alcotest.opam
+++ b/alcotest.opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.03.0"}
-  "fmt" {>= "0.8.6"}
+  "fmt" {>= "0.8.7"}
   "astring"
   "cmdliner"
   "uuidm"

--- a/dune-project
+++ b/dune-project
@@ -25,7 +25,7 @@ tests to run.
 ")
  (depends
   (ocaml (>= 4.03.0))
-  (fmt (>= 0.8.6))
+  (fmt (>= 0.8.7))
   astring
   cmdliner
   uuidm

--- a/src/alcotest-engine/test.ml
+++ b/src/alcotest-engine/test.ml
@@ -137,7 +137,7 @@ let reject (type a) =
   (module M : TESTABLE with type t = M.t)
 
 let show_assert msg =
-  Utils.Fmt.(flush stdout) () (* Flush any test stdout preceding the assert *);
+  Fmt.(flush stdout) () (* Flush any test stdout preceding the assert *);
   Format.eprintf "%a %s\n%!" Fmt.(styled `Yellow string) "ASSERT" msg
 
 let check_err fmt =

--- a/src/alcotest-engine/utils.ml
+++ b/src/alcotest-engine/utils.ml
@@ -27,14 +27,3 @@ end
 module Result = struct
   let map f = function Ok x -> Ok (f x) | Error e -> Error e
 end
-
-module Fmt = struct
-  [@@@warning "-32"]
-
-  (* Re-implement [flush] for pre-0.8.6 compatibility *)
-  let flush ppf _ = Format.pp_print_flush ppf ()
-
-  [@@@warning "+32"]
-
-  include Fmt
-end

--- a/src/alcotest-engine/utils.mli
+++ b/src/alcotest-engine/utils.mli
@@ -11,9 +11,3 @@ end
 module Result : sig
   val map : ('a -> 'b) -> ('a, 'e) result -> ('b, 'e) result
 end
-
-module Fmt : sig
-  include module type of Fmt
-
-  val flush : 'a t
-end

--- a/src/alcotest/alcotest.ml
+++ b/src/alcotest/alcotest.ml
@@ -2,7 +2,6 @@ include Alcotest_engine.Test
 
 module Unix (M : Alcotest_engine.Monad.S) = struct
   module M = Alcotest_engine.Monad.Extend (M)
-  module Fmt = Alcotest_engine.Private.Utils.Fmt
 
   module Unix = struct
     open Astring

--- a/test/e2e/alcotest-lwt/dune
+++ b/test/e2e/alcotest-lwt/dune
@@ -1,0 +1,4 @@
+(env
+ (_
+  (env-vars
+   (ALCOTEST_COLOR auto))))

--- a/test/e2e/alcotest-lwt/failing/dune
+++ b/test/e2e/alcotest-lwt/failing/dune
@@ -1,3 +1,8 @@
+(env
+ (_
+  (env-vars
+   (ALCOTEST_COLOR auto))))
+
 (include dune.inc)
 
 (rule

--- a/test/e2e/alcotest-lwt/passing/dune
+++ b/test/e2e/alcotest-lwt/passing/dune
@@ -1,3 +1,8 @@
+(env
+ (_
+  (env-vars
+   (ALCOTEST_COLOR auto))))
+
 (include dune.inc)
 
 (rule

--- a/test/e2e/alcotest/failing/dune
+++ b/test/e2e/alcotest/failing/dune
@@ -1,3 +1,8 @@
+(env
+ (_
+  (env-vars
+   (ALCOTEST_COLOR auto))))
+
 (include dune.inc)
 
 (rule

--- a/test/e2e/alcotest/inside-dune/color-default.expected
+++ b/test/e2e/alcotest/inside-dune/color-default.expected
@@ -1,0 +1,7 @@
+Testing [1mtest_color[0m.
+This run has ID `<uuid>`.
+[33m ...[0m                [36malpha[0m          0   Output may or may not contain ANSII escape codes.[32m[OK][0m                [36malpha[0m          0   Output may or may not contain ANSII escape codes.
+[33m ...[0m                [36malpha[0m          1   according to whether or not [--color] is set.[32m[OK][0m                [36malpha[0m          1   according to whether or not [--color] is set.
+[33m ...[0m                [36malpha[0m          2   (See the corresponding [dune] file.).[32m[OK][0m                [36malpha[0m          2   (See the corresponding [dune] file.).
+The full test results are available in `<build-context>/_build/_tests/<uuid>`.
+[32mTest Successful[0m in <test-duration>s. 3 tests run.

--- a/test/e2e/alcotest/inside-dune/color-overridden.expected
+++ b/test/e2e/alcotest/inside-dune/color-overridden.expected
@@ -1,0 +1,7 @@
+Testing test_color.
+This run has ID `<uuid>`.
+ ...                alpha          0   Output may or may not contain ANSII escape codes.[OK]                alpha          0   Output may or may not contain ANSII escape codes.
+ ...                alpha          1   according to whether or not [--color] is set.[OK]                alpha          1   according to whether or not [--color] is set.
+ ...                alpha          2   (See the corresponding [dune] file.).[OK]                alpha          2   (See the corresponding [dune] file.).
+The full test results are available in `<build-context>/_build/_tests/<uuid>`.
+Test Successful in <test-duration>s. 3 tests run.

--- a/test/e2e/alcotest/inside-dune/dune
+++ b/test/e2e/alcotest/inside-dune/dune
@@ -1,0 +1,49 @@
+(executable
+ (name test_color)
+ (libraries alcotest))
+
+;; Run `test_color` with no command-line options
+
+(rule
+ (target color-default.actual)
+ (action
+  (with-outputs-to
+   %{target}
+   ;; No `--color` command-line option passed → output should be colored
+   (run %{dep:test_color.exe}))))
+
+(rule
+ (target color-default.processed)
+ (action
+  (with-outputs-to
+   %{target}
+   (run ../../strip_randomness.exe %{dep:color-default.actual}))))
+
+(rule
+ (alias runtest)
+ (package alcotest)
+ (action
+  (diff color-default.expected color-default.processed)))
+
+;; Run `test_color` with `--color=auto`
+
+(rule
+ (target color-overridden.actual)
+ (action
+  (with-outputs-to
+   %{target}
+   ;; `--color=auto` passed → output should _not_ be colored due to Dune's buffering
+   (run %{dep:test_color.exe} --color=auto))))
+
+(rule
+ (target color-overridden.processed)
+ (action
+  (with-outputs-to
+   %{target}
+   (run ../../strip_randomness.exe %{dep:color-overridden.actual}))))
+
+(rule
+ (alias runtest)
+ (package alcotest)
+ (action
+  (diff color-overridden.expected color-overridden.processed)))

--- a/test/e2e/alcotest/inside-dune/test_color.ml
+++ b/test/e2e/alcotest/inside-dune/test_color.ml
@@ -1,0 +1,12 @@
+let () =
+  let open Alcotest in
+  let id () = () in
+  run "test_color"
+    [
+      ( "alpha",
+        [
+          test_case "Output may or may not contain ANSII escape codes" `Quick id;
+          test_case "according to whether or not [--color] is set." `Quick id;
+          test_case "(See the corresponding [dune] file.)" `Quick id;
+        ] );
+    ]

--- a/test/e2e/alcotest/passing/dune
+++ b/test/e2e/alcotest/passing/dune
@@ -1,3 +1,8 @@
+(env
+ (_
+  (env-vars
+   (ALCOTEST_COLOR auto))))
+
 (include dune.inc)
 
 (rule

--- a/test/e2e/dune
+++ b/test/e2e/dune
@@ -1,3 +1,8 @@
+(env
+ (_
+  (env-vars
+   (ALCOTEST_COLOR auto))))
+
 (executable
  (name gen_dune_rules)
  (libraries cmdliner fmt)

--- a/test/e2e/dune
+++ b/test/e2e/dune
@@ -1,8 +1,3 @@
-(env
- (_
-  (env-vars
-   (ALCOTEST_COLOR auto))))
-
 (executable
  (name gen_dune_rules)
  (libraries cmdliner fmt)

--- a/test/e2e/strip_randomness.ml
+++ b/test/e2e/strip_randomness.ml
@@ -29,7 +29,10 @@ let time_replace =
         group
           (alt
              [
-               str "Test Successful in ";
+               opt cntrl (* Maybe ANSII escape, depending on [--color] *);
+               str "Test Successful";
+               opt cntrl;
+               str " in ";
                seq [ rep1 digit; str " error! in " ];
                seq [ rep1 digit; str " errors! in " ];
              ]);


### PR DESCRIPTION
This changes the default value of the `--color` flag to `always` rather than `auto` when the `INSIDE_DUNE` variable is set.

As discussed before (see https://github.com/mirage/alcotest/issues/207 and https://github.com/ocaml/dune/issues/145), Alcotest output is not coloured by default if run via `dune runtest`, since Dune's buffering mechanism keeps the test process from having direct access to the terminal.

We now have the `ALCOTEST_COLOR` variable for experienced users to override this behaviour, but I suspect the better solution is to default to _always_ showing colours, so that new users are not surprised by this interaction. People who really don't want colours can still disable it with the environment variable or the command-line option.

Travis CI appears to filter out any ANSII colour codes in its logs (see https://travis-ci.org/github/mirage/irmin/jobs/686951739#L3684).