### PR TITLE
Document the manpage output

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ a simple `TESTABLE` module type, a `check` function to assert test
 predicates and a `run` function to perform a list of `unit -> unit`
 test callbacks.
 
-Alcotest provides a quiet and colorful output where only faulty runs
-are fully displayed at the end of the run (with the full logs ready to
-inspect), with a simple (yet expressive) query language to select the
-tests to run.
+Alcotest provides a quiet and colorful output where only faulty runs are fully
+displayed at the end of the run (with the full logs ready to inspect), with a
+simple (yet expressive) query language to select the tests to run. See [the
+manpage](./alcotest-help.txt) for details.
 
 [![OCaml-CI Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Fmirage%2Falcotest%2Fmaster&logo=ocaml)](https://ci.ocamllabs.io/github/mirage/alcotest)
 [![TravisCI Build Status](https://travis-ci.org/mirage/alcotest.svg)](https://travis-ci.org/mirage/alcotest)

--- a/alcotest-help.txt
+++ b/alcotest-help.txt
@@ -31,7 +31,7 @@ OPTIONS
        --json
            Display JSON for the results, to be used by a script.
 
-       -o DIR (absent=/home/craigfe/t/alcotest/_build/default/_build/_tests)
+       -o DIR (absent=<build-context>/_build/_tests)
            Where to store the log files of the tests.
 
        -q, --quick-tests (absent ALCOTEST_QUICK_TESTS env)

--- a/alcotest-help.txt
+++ b/alcotest-help.txt
@@ -1,0 +1,67 @@
+NAME
+       simple.exe - Run all the tests.
+
+SYNOPSIS
+       simple.exe COMMAND ...
+
+COMMANDS
+       list
+           List all available tests.
+
+       test
+           Run a subset of the tests.
+
+OPTIONS
+       -c, --compact (absent ALCOTEST_COMPACT env)
+           Compact the output of the tests
+
+       --color=WHEN (absent ALCOTEST_COLOR env)
+           Colorize the output. WHEN must be one of `auto', `always' or
+           `never'. Defaults to `always' when running inside Dune, otherwise
+           defaults to `auto'.
+
+       -e, --show-errors (absent ALCOTEST_SHOW_ERRORS env)
+           Display the test errors.
+
+       --help[=FMT] (default=auto)
+           Show this help in format FMT. The value FMT must be one of `auto',
+           `pager', `groff' or `plain'. With `auto', the format is `pager` or
+           `plain' whenever the TERM env var is `dumb' or undefined.
+
+       --json
+           Display JSON for the results, to be used by a script.
+
+       -o DIR (absent=/home/craigfe/t/alcotest/_build/default/_build/_tests)
+           Where to store the log files of the tests.
+
+       -q, --quick-tests (absent ALCOTEST_QUICK_TESTS env)
+           Run only the quick tests.
+
+       --tail-errors=N (absent ALCOTEST_TAIL_ERRORS env)
+           Show only the last N lines of output in case of an error.
+
+       -v, --verbose (absent ALCOTEST_VERBOSE env)
+           Display the test outputs. WARNING: when using this option the
+           output logs will not be available for further inspection.
+
+ENVIRONMENT
+       These environment variables affect the execution of simple.exe:
+
+       ALCOTEST_COLOR
+           See option --color.
+
+       ALCOTEST_COMPACT
+           See option --compact.
+
+       ALCOTEST_QUICK_TESTS
+           See option --quick-tests.
+
+       ALCOTEST_SHOW_ERRORS
+           See option --show-errors.
+
+       ALCOTEST_TAIL_ERRORS
+           See option --tail-errors.
+
+       ALCOTEST_VERBOSE
+           See option --verbose.
+

--- a/dune
+++ b/dune
@@ -1,0 +1,9 @@
+(rule
+ (with-stdout-to
+  alcotest-help.txt.gen
+  (run examples/simple.exe --help=plain)))
+
+(rule
+ (alias runtest)
+ (action
+  (diff alcotest-help.txt alcotest-help.txt.gen)))

--- a/dune
+++ b/dune
@@ -1,9 +1,18 @@
 (rule
  (with-stdout-to
-  alcotest-help.txt.gen
+  alcotest-help.txt.actual
   (run examples/simple.exe --help=plain)))
+
+(rule
+ (target alcotest-help.txt.processed)
+ (deps
+  (:strip-randomness test/e2e/strip_randomness.exe))
+ (action
+  (with-outputs-to
+   %{target}
+   (run %{strip-randomness} %{dep:alcotest-help.txt}))))
 
 (rule
  (alias runtest)
  (action
-  (diff alcotest-help.txt alcotest-help.txt.gen)))
+  (diff alcotest-help.txt alcotest-help.txt.processed)))

--- a/test/e2e/strip_randomness.ml
+++ b/test/e2e/strip_randomness.ml
@@ -4,11 +4,17 @@ let standardise_filesep =
 
 let build_context_replace =
   let open Re in
-  let t = seq [ char '`'; rep any; str "_build"; group (rep any); char '`' ] in
+  let lterm, rterm =
+    (* Contexts in which directories are printed (tests, manpage output etc.). *)
+    ( group (alt [ char '`'; str "(absent=" ]),
+      group (alt [ char '`'; char ')' ]) )
+  in
+
+  let t = seq [ lterm; rep any; str "_build"; group (rep any); rterm ] in
   let re = compile t in
   replace ~all:true re ~f:(fun g ->
-      let test_dir = standardise_filesep (Group.get g 1) in
-      "`<build-context>/_build" ^ test_dir ^ "`")
+      let test_dir = standardise_filesep (Group.get g 2) in
+      Group.get g 1 ^ "<build-context>/_build" ^ test_dir ^ Group.get g 3)
 
 let uuid_replace =
   let open Re in


### PR DESCRIPTION
Since the manpage is auto-generated from the `Cmdliner` specification, it's
easy to miss changes to its output in PRs. This adds a simple expect test to
make it more obvious what is changing.

It may also be useful as a quick reference for the supported options, so I've
linked to it from the README.