### PR TITLE
Add Ocaml `bytes` testable.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 - Fix handling of test names by normalizing them, allowing all UTF-8 characters
   (#249, @gs0510)
 
+- Add a testable for the `bytes` type. (#253, @mefyl)
+
 ### 1.1.0 (2020-04-03)
 
 - Fix handling of CLI options for `Alcotest_{async,lwt}.run`. (#222, @CraigFe)

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ clean:
 	dune clean
 
 format:
-	ocamlformat --inplace $(git ls-files '*.ml' '*.mli')
+	dune build --auto-promote @fmt

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,5 @@ test:
 clean:
 	dune clean
 
-.PHONY: all clean
+format:
+	ocamlformat --inplace $(git ls-files '*.ml' '*.mli')

--- a/src/alcotest-engine/test.ml
+++ b/src/alcotest-engine/test.ml
@@ -63,7 +63,8 @@ let char = testable Fmt.char ( = )
 
 let string = testable Fmt.string ( = )
 
-let bytes = testable (fun fmt bytes -> Fmt.fmt "%S" fmt (Bytes.to_string bytes)) ( = )
+let bytes =
+  testable (fun fmt bytes -> Fmt.fmt "%S" fmt (Bytes.to_string bytes)) ( = )
 
 let bool = testable Fmt.bool ( = )
 

--- a/src/alcotest-engine/test.ml
+++ b/src/alcotest-engine/test.ml
@@ -63,6 +63,8 @@ let char = testable Fmt.char ( = )
 
 let string = testable Fmt.string ( = )
 
+let bytes = testable (fun fmt bytes -> Fmt.fmt "%S" fmt (Bytes.to_string bytes)) ( = )
+
 let bool = testable Fmt.bool ( = )
 
 let unit = testable (Fmt.unit "()") ( = )

--- a/src/alcotest-engine/test.mli
+++ b/src/alcotest-engine/test.mli
@@ -60,6 +60,9 @@ val char : char testable
 val string : string testable
 (** [string] tests OCaml strings. *)
 
+val bytes : bytes testable
+(** [bytes] tests OCaml bytes. *)
+
 val unit : unit testable
 (** [unit] tests unit values (useful for functions with side-effects). *)
 

--- a/test/e2e/alcotest/failing/check_basic.expected
+++ b/test/e2e/alcotest/failing/check_basic.expected
@@ -7,6 +7,7 @@ This run has ID `<uuid>`.
  ...                different basic              4   float.[FAIL]              different basic              4   float.
  ...                different basic              5   char.[FAIL]              different basic              5   char.
  ...                different basic              6   string.[FAIL]              different basic              6   string.
+ ...                different basic              7   bytes.[FAIL]              different basic              7   bytes.
  ...                different composite          0   list.[FAIL]              different composite          0   list.
  ...                different composite          1   array.[FAIL]              different composite          1   array.
  ...                different composite          2   option some.[FAIL]              different composite          2   option some.
@@ -20,4 +21,4 @@ true, got
 false.
 
 The full test results are available in `<build-context>/_build/_tests/<uuid>`.
-12 errors! in <test-duration>s. 12 tests run.
+13 errors! in <test-duration>s. 13 tests run.

--- a/test/e2e/alcotest/failing/check_basic.ml
+++ b/test/e2e/alcotest/failing/check_basic.ml
@@ -15,6 +15,7 @@ let () =
           id_case (float 0.0) "float" 1.0 2.0;
           id_case char "char" 'a' 'b';
           id_case string "string" "Lorem ipsum" "dolor sit amet.";
+          id_case bytes "bytes" (Bytes.of_string "\x01\x02\x03") (Bytes.of_string "\x01\x00\x03");
         ] );
       ( "different composite",
         [

--- a/test/e2e/alcotest/failing/check_basic.ml
+++ b/test/e2e/alcotest/failing/check_basic.ml
@@ -15,7 +15,9 @@ let () =
           id_case (float 0.0) "float" 1.0 2.0;
           id_case char "char" 'a' 'b';
           id_case string "string" "Lorem ipsum" "dolor sit amet.";
-          id_case bytes "bytes" (Bytes.of_string "\x01\x02\x03") (Bytes.of_string "\x01\x00\x03");
+          id_case bytes "bytes"
+            (Bytes.of_string "\x01\x02\x03")
+            (Bytes.of_string "\x01\x00\x03");
         ] );
       ( "different composite",
         [

--- a/test/e2e/alcotest/passing/check_basic.expected
+++ b/test/e2e/alcotest/passing/check_basic.expected
@@ -8,6 +8,7 @@ This run has ID `<uuid>`.
  ...                reflexive basic              5   float.[OK]                reflexive basic              5   float.
  ...                reflexive basic              6   char.[OK]                reflexive basic              6   char.
  ...                reflexive basic              7   string.[OK]                reflexive basic              7   string.
+ ...                reflexive basic              8   bytes.[OK]                reflexive basic              8   bytes.
  ...                reflexive composite          0   empty list.[OK]                reflexive composite          0   empty list.
  ...                reflexive composite          1   non-empty list.[OK]                reflexive composite          1   non-empty list.
  ...                reflexive composite          2   empty array.[OK]                reflexive composite          2   empty array.
@@ -23,4 +24,4 @@ This run has ID `<uuid>`.
  ...                fuzzy equality               1   sorted list.[OK]                fuzzy equality               1   sorted list.
  ...                labeled check                0   passing.[OK]                labeled check                0   passing.
 The full test results are available in `<build-context>/_build/_tests/<uuid>`.
-Test Successful in <test-duration>s. 22 tests run.
+Test Successful in <test-duration>s. 23 tests run.

--- a/test/e2e/alcotest/passing/check_basic.ml
+++ b/test/e2e/alcotest/passing/check_basic.ml
@@ -53,6 +53,7 @@ let () =
           id_case (float 0.0) "float" 1.0;
           id_case char "char" 'a';
           id_case string "string" "Lorem ipsum dolor sit amet.";
+          id_case bytes "bytes" (Bytes.of_string "\x01\x02\x03");
         ] );
       ( "reflexive composite",
         [


### PR DESCRIPTION
Printing relies on `Format` escaping with `%S`, which I think is exactly what we want : plain text as long as it's printable, escaped otherwise.