### PR TITLE
Get string lengths in UTF-8 chars when appropriate

### DIFF
--- a/src/alcotest-engine/core.ml
+++ b/src/alcotest-engine/core.ml
@@ -14,7 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Astring
 open Model
 open Utils
 
@@ -107,6 +106,7 @@ struct
     mutable errors : unit Fmt.t list;
     (* runtime options. *)
     max_label : int;
+        (** Longest test label in the suite, in UTF-8 characters. *)
     speed_level : speed_level;
     show_errors : bool;
     json : bool;
@@ -366,7 +366,7 @@ struct
     |> Fmt.(list ~sep:(const string "\n") (pp_info t) stdout)
 
   let register (type a) (t : a t) (name, (ts : a test_case list)) : a t =
-    let max_label = max t.max_label (String.length name) in
+    let max_label = max t.max_label (String.length_utf8 name) in
     let test_details =
       List.mapi
         (fun index (doc, speed, test) ->

--- a/src/alcotest-engine/pp.ml
+++ b/src/alcotest-engine/pp.ml
@@ -15,7 +15,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Astring
 open Model
 open Utils
 
@@ -43,7 +42,7 @@ let left_c = 14
 
 let left nb pp ppf a =
   let s = Fmt.to_to_string pp a in
-  let nb = nb - String.length s in
+  let nb = nb - String.length_utf8 s in
   if nb <= 0 then pp ppf a
   else (
     pp ppf a;
@@ -164,7 +163,7 @@ let with_surrounding_box (type a) (f : a Fmt.t) : a Fmt.t =
   (* Peek at the value being pretty-printed to determine the length of the box
      we're going to need. Fortunately, this will not include ANSII colour
      escapes. *)
-  let true_width = Fmt.kstr String.length "| %a |" f a in
+  let true_width = Fmt.kstr String.length_utf8 "| %a |" f a in
   let min_width = terminal_width () in
   let width = max min_width true_width in
 

--- a/src/alcotest-engine/utils.ml
+++ b/src/alcotest-engine/utils.ml
@@ -1,5 +1,11 @@
 let ( >> ) f g x = x |> f |> g
 
+module String = struct
+  include Astring.String
+
+  let length_utf8 = Uutf.String.fold_utf_8 (fun count _ _ -> count + 1) 0
+end
+
 module List = struct
   include List
 

--- a/src/alcotest-engine/utils.mli
+++ b/src/alcotest-engine/utils.mli
@@ -1,5 +1,12 @@
 val ( >> ) : ('a -> 'b) -> ('b -> 'c) -> 'a -> 'c
 
+module String : sig
+  include module type of Astring.String
+
+  val length_utf8 : string -> int
+  (** Get the length of a string in UTF-8 characters and malformed segments. *)
+end
+
 module List : sig
   include module type of List
 

--- a/test/e2e/alcotest/passing/unicode_testname.expected
+++ b/test/e2e/alcotest/passing/unicode_testname.expected
@@ -1,8 +1,8 @@
 Testing `Suite name containing file separators / and non-ASCII characters 🔥'.
 This run has ID `<uuid>'.
 
-  ...           🔥                0   Non ASCII unicode character.  [OK]          🔥                0   Non ASCII unicode character.
-  ...           🔥a-b             0   Non ASCII and ASCII characters.  [OK]          🔥a-b             0   Non ASCII and ASCII characters.
+  ...           🔥             0   Non ASCII unicode character.  [OK]          🔥             0   Non ASCII unicode character.
+  ...           🔥a-b          0   Non ASCII and ASCII characters.  [OK]          🔥a-b          0   Non ASCII and ASCII characters.
 
 Full test results in `<build-context>/_build/_tests/<test-dir>'.
 Test Successful in <test-duration>s. 2 tests run.


### PR DESCRIPTION
We're currently using `String.length` in a few places to predict the width of
its printed representation. When the user-supplied string contains UTF-8
characters, this isn't sufficient. This PR gets the length in UTF-8 characters
instead.