### PR TITLE
Allow period character to appear unescaped in test names

### DIFF
--- a/src/alcotest-engine/model.ml
+++ b/src/alcotest-engine/model.ml
@@ -16,7 +16,8 @@ let escape str =
     | `Uchar u ->
         if Uchar.is_char u then
           match Uchar.to_char u with
-          | ('A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '-' | ' ') as c ->
+          | ('A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '-' | ' ' | '.') as c
+            ->
               Buffer.add_char buf c
           | _ -> add_codepoint buf u
         else add_codepoint buf u


### PR DESCRIPTION
We use `.` as a separator quite frequently in test and suite names, for
instance to refer to findlib names like `index.unix`. AFAIK, this character is
safe to use in filesystems, so we might as well allow it.