### PR TITLE
Emit an error when the user supplies an empty suite name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
-### unreleased
+### Unreleased
+
+- Fail gracefully when the user supplies an empty suite name. (#265, @CraigFe)
 
 - Fix compatibility with `fmt.0.8.8+dune` by adding a missing `fmt` dependency
   in `alcotest`'s dune file (#266, @NathanReb)

--- a/src/alcotest-engine/model.ml
+++ b/src/alcotest-engine/model.ml
@@ -51,8 +51,8 @@ end = struct
 
   let v ~name ~index =
     let file =
-      let name = name |> escape in
-      Fmt.str "%s.%03d.output" name index
+      let name = name |> escape |> function "" -> "" | n -> n ^ "." in
+      Fmt.str "%s%03d.output" name index
     in
     { name; file; index }
 

--- a/src/alcotest-engine/pp.ml
+++ b/src/alcotest-engine/pp.ml
@@ -218,3 +218,7 @@ let suite_results ~verbose ~show_errors ~json ~compact ~log_dir ppf r =
         if not verbose then pp_full_logs ppf log_dir;
         pp_summary ppf r );
       Format.pp_close_box ppf ()
+
+let user_error msg =
+  Fmt.epr "%a: %s\n" Fmt.(styled `Red string) "ERROR" msg;
+  exit 1

--- a/src/alcotest-engine/pp.mli
+++ b/src/alcotest-engine/pp.mli
@@ -74,3 +74,6 @@ val pp_plural : int Fmt.t
       let n = List.length items in
       Fmt.pr "Found %i item%a." n pp_plural n
     ]} *)
+
+val user_error : string -> _
+(** Raise a user error, then fail. *)

--- a/test/e2e/alcotest/failing/dune.inc
+++ b/test/e2e/alcotest/failing/dune.inc
@@ -4,6 +4,7 @@
    check_long
    compact
    duplicate_test_names
+   empty_suite_name
    exception_in_test
    filter_all_tests
    invalid_arg_in_test
@@ -18,6 +19,7 @@
    check_long
    compact
    duplicate_test_names
+   empty_suite_name
    exception_in_test
    filter_all_tests
    invalid_arg_in_test
@@ -127,6 +129,31 @@
  (package alcotest)
  (action
    (diff duplicate_test_names.expected duplicate_test_names.processed)))
+
+(rule
+ (target empty_suite_name.actual)
+ (action
+  (with-outputs-to %{target}
+   (run ../../expect_failure.exe %{dep:empty_suite_name.exe})
+  )
+ )
+)
+
+(rule
+ (target empty_suite_name.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../../strip_randomness.exe %{dep:empty_suite_name.actual})
+  )
+ )
+)
+
+
+(rule
+ (alias runtest)
+ (package alcotest)
+ (action
+   (diff empty_suite_name.expected empty_suite_name.processed)))
 
 (rule
  (target exception_in_test.actual)

--- a/test/e2e/alcotest/failing/duplicate_test_names.expected
+++ b/test/e2e/alcotest/failing/duplicate_test_names.expected
@@ -1,3 +1,1 @@
-duplicate_test_names.exe: internal error, uncaught exception:
-                          Alcotest_engine.Model.Registration_error("Duplicate test path: duped")
-                          
+ERROR: Duplicate test path: `duped'

--- a/test/e2e/alcotest/failing/empty_suite_name.expected
+++ b/test/e2e/alcotest/failing/empty_suite_name.expected
@@ -1,0 +1,1 @@
+ERROR: Suite name cannot cannot be empty. Please pass a non-empty string to `run`.

--- a/test/e2e/alcotest/failing/empty_suite_name.ml
+++ b/test/e2e/alcotest/failing/empty_suite_name.ml
@@ -1,0 +1,3 @@
+let () =
+  Alcotest.run ""
+    [ ("alpha", [ Alcotest.test_case "1" `Quick (fun () -> assert false) ]) ]

--- a/test/e2e/alcotest/passing/dune.inc
+++ b/test/e2e/alcotest/passing/dune.inc
@@ -8,6 +8,7 @@
    check_basic
    cli_verbose
    compact
+   empty_test_name
    filter_name
    filter_name_regex
    json_output
@@ -29,6 +30,7 @@
    check_basic
    cli_verbose
    compact
+   empty_test_name
    filter_name
    filter_name_regex
    json_output
@@ -241,6 +243,31 @@
  (package alcotest)
  (action
    (diff compact.expected compact.processed)))
+
+(rule
+ (target empty_test_name.actual)
+ (action
+  (with-outputs-to %{target}
+   (run %{dep:empty_test_name.exe})
+  )
+ )
+)
+
+(rule
+ (target empty_test_name.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../../strip_randomness.exe %{dep:empty_test_name.actual})
+  )
+ )
+)
+
+
+(rule
+ (alias runtest)
+ (package alcotest)
+ (action
+   (diff empty_test_name.expected empty_test_name.processed)))
 
 (rule
  (target filter_name.actual)

--- a/test/e2e/alcotest/passing/empty_test_name.expected
+++ b/test/e2e/alcotest/passing/empty_test_name.expected
@@ -1,0 +1,7 @@
+Testing `<suite-name>'.
+This run has ID `<uuid>'.
+
+  ...                     0   1.  [OK]                    0   1.
+
+Full test results in `<build-context>/_build/_tests/<test-dir>'.
+Test Successful in <test-duration>s. 1 test run.

--- a/test/e2e/alcotest/passing/empty_test_name.ml
+++ b/test/e2e/alcotest/passing/empty_test_name.ml
@@ -1,0 +1,3 @@
+let () =
+  Alcotest.run "<suite-name>"
+    [ ("", [ Alcotest.test_case "1" `Quick (fun () -> ()) ]) ]


### PR DESCRIPTION
Fix https://github.com/mirage/alcotest/issues/264.

This emits an error message when the user supplies an empty test suite name, which previously raised an uncaught exception due to trying to create a corresponding symlink with an empty name. As discussed in the linked issue, it seems better to avoid empty suite names altogether.

Also adds a test for the similar case for empty _test_ names, which isn't as problematic since we already append integers to these files on disk. In this case, I just chose to alter the filenames slightly to make sure that they don't start with a `.`.

Introduces a common `user_error` function for handling such cases.