### PR TITLE
Explicitly declare Alcotest's deps on fmt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### unreleased
+
+- Fix compatibility with `fmt.0.8.8+dune` by adding a missing `fmt` dependency
+  in `alcotest`'s dune file (#266, @NathanReb)
+
 ### 1.2.1 (2020-07-15)
 
 - Surround pretty-printed diffs with quotes to make trailing whitespace more

--- a/src/alcotest/dune
+++ b/src/alcotest/dune
@@ -1,3 +1,3 @@
 (library
  (public_name alcotest)
- (libraries alcotest.engine astring fmt.tty))
+ (libraries alcotest.engine astring fmt fmt.tty))


### PR DESCRIPTION
It was transitively working thanks to fmt.tty with the upstream fmt version but trying to use fmt's dune port failed.