### PR TITLE
Upgrade to OCamlformat v0.15.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version = 0.14.1
+version = 0.15.0
 break-infix=fit-or-vertical
 parse-docstrings


### PR DESCRIPTION
- reformats the code to be compliant with OCamlformat v0.15.0
- updates the `.ocamlformat` file accordingly