### PR TITLE
Fix handling of `~and_exit` parameter when running via CLI functor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+- Fix a bug in the handling of the `~and_exit:false` option when the test suite
+  fails. (#271, @CraigFe)
+
 ### 1.2.2 (2020-08-26)
 
 - Fail gracefully when the user supplies an empty suite name. (#265, @CraigFe)


### PR DESCRIPTION
Fix https://github.com/mirage/alcotest/issues/270.

The logic that processes `Cmdliner` results was incorrect (again), resulting in failure to respect `~and_exit:false` when an exception is raised by the user code. In future, we should consolidate this parameter handling logic in one place (i.e. in `Core` when necessary) to avoid such bugs.

Also cleans up the `bad.ml` example slightly, which was a bit hard to read before.