### PR TITLE
Assign all test suites distinct names

### DIFF
--- a/test/e2e/alcotest-lwt/failing/async_failure.expected
+++ b/test/e2e/alcotest-lwt/failing/async_failure.expected
@@ -1,4 +1,4 @@
-Testing `foo'.
+Testing `test/e2e/alcotest-lwt/failing/async_failure.ml'.
 This run has ID `<uuid>'.
 
 > [FAIL]        all          0   one.

--- a/test/e2e/alcotest-lwt/failing/async_failure.ml
+++ b/test/e2e/alcotest-lwt/failing/async_failure.ml
@@ -10,7 +10,7 @@ let test_lwt switch () =
 let () =
   let open Alcotest_lwt in
   Lwt_main.run
-  @@ run "foo"
+  @@ run __FILE__
        [
          ( "all",
            [

--- a/test/e2e/alcotest-lwt/failing/fail_with.expected
+++ b/test/e2e/alcotest-lwt/failing/fail_with.expected
@@ -1,4 +1,4 @@
-Testing `foo'.
+Testing `test/e2e/alcotest-lwt/failing/fail_with.ml'.
 This run has ID `<uuid>'.
 
 > [FAIL]        all          0   one.

--- a/test/e2e/alcotest-lwt/failing/fail_with.ml
+++ b/test/e2e/alcotest-lwt/failing/fail_with.ml
@@ -3,7 +3,7 @@ let test_lwt _switch () = Lwt.fail_with "should fail"
 let () =
   let open Alcotest_lwt in
   Lwt_main.run
-  @@ run "foo"
+  @@ run __FILE__
        [
          ( "all",
            [

--- a/test/e2e/alcotest/failing/check_basic.expected
+++ b/test/e2e/alcotest/failing/check_basic.expected
@@ -1,4 +1,4 @@
-Testing `check_basic'.
+Testing `test/e2e/alcotest/failing/check_basic.ml'.
 This run has ID `<uuid>'.
 
 ASSERT bool

--- a/test/e2e/alcotest/failing/check_basic.ml
+++ b/test/e2e/alcotest/failing/check_basic.ml
@@ -4,7 +4,7 @@ let id_case typ typ_str v1 v2 =
 
 let () =
   let open Alcotest in
-  run ~verbose:true "check_basic"
+  run ~verbose:true __FILE__
     [
       ( "different basic",
         [

--- a/test/e2e/alcotest/failing/check_long.expected
+++ b/test/e2e/alcotest/failing/check_long.expected
@@ -1,4 +1,4 @@
-Testing `check_long'.
+Testing `test/e2e/alcotest/failing/check_long.ml'.
 This run has ID `<uuid>'.
 
 ASSERT list

--- a/test/e2e/alcotest/failing/check_long.ml
+++ b/test/e2e/alcotest/failing/check_long.ml
@@ -36,5 +36,5 @@ let test_nested_options =
 
 let () =
   let open Alcotest in
-  run ~verbose:true "check_long"
+  run ~verbose:true __FILE__
     [ ("wrapping", [ test_char_list; test_int64_array; test_nested_options ]) ]

--- a/test/e2e/alcotest/failing/compact.expected
+++ b/test/e2e/alcotest/failing/compact.expected
@@ -1,4 +1,4 @@
-Testing `failing compact output'.
+Testing `test/e2e/alcotest/failing/compact.ml'.
 This run has ID `<uuid>'.
 
 ..F...

--- a/test/e2e/alcotest/failing/compact.ml
+++ b/test/e2e/alcotest/failing/compact.ml
@@ -2,7 +2,7 @@ let () =
   let open Alcotest in
   let passing s = test_case s `Quick (fun () -> ()) in
   let failing s = test_case s `Quick (fun () -> failwith "Error") in
-  run ~compact:true "failing compact output"
+  run ~compact:true __FILE__
     [
       ("alpha", [ passing "1"; passing "2"; failing "3"; passing "4" ]);
       ("beta", [ passing "1" ]);

--- a/test/e2e/alcotest/failing/duplicate_test_names.ml
+++ b/test/e2e/alcotest/failing/duplicate_test_names.ml
@@ -1,7 +1,7 @@
 (** Ensure that suites with duplicate test names are rejected. *)
 
 let () =
-  Alcotest.run "suite-with-duplicate-names"
+  Alcotest.run __FILE__
     [
       ("duped", [ Alcotest.test_case "1" `Quick (fun () -> assert false) ]);
       ("duped", [ Alcotest.test_case "2" `Quick (fun () -> assert false) ]);

--- a/test/e2e/alcotest/failing/exception_in_test.expected
+++ b/test/e2e/alcotest/failing/exception_in_test.expected
@@ -1,4 +1,4 @@
-Testing `suite-with-failures'.
+Testing `test/e2e/alcotest/failing/exception_in_test.ml'.
 This run has ID `<uuid>'.
 
   [OK]          test-a          0   Passing.

--- a/test/e2e/alcotest/failing/exception_in_test.ml
+++ b/test/e2e/alcotest/failing/exception_in_test.ml
@@ -2,7 +2,7 @@ exception Foo of string
 
 let () =
   let open Alcotest in
-  run "suite-with-failures"
+  run __FILE__
     [
       ( "test-a",
         [

--- a/test/e2e/alcotest/failing/filter_all_tests.expected
+++ b/test/e2e/alcotest/failing/filter_all_tests.expected
@@ -1,4 +1,4 @@
 Invalid request (no tests to run, filter skipped everything)!
-Testing `suite-with-duplicate-names'.
+Testing `test/e2e/alcotest/failing/filter_all_tests.ml'.
 This run has ID `<uuid>'.
 

--- a/test/e2e/alcotest/failing/filter_all_tests.ml
+++ b/test/e2e/alcotest/failing/filter_all_tests.ml
@@ -1,7 +1,7 @@
 (** Ensure that filters which eliminate all tests are rejected. *)
 
 let () =
-  Alcotest.run "suite-with-duplicate-names"
+  Alcotest.run __FILE__
     [
       ("foo", [ Alcotest.test_case "1" `Quick (fun () -> assert false) ]);
       ("bar", [ Alcotest.test_case "2" `Quick (fun () -> assert false) ]);

--- a/test/e2e/alcotest/failing/invalid_arg_in_test.expected
+++ b/test/e2e/alcotest/failing/invalid_arg_in_test.expected
@@ -1,4 +1,4 @@
-Testing `suite-with-failures'.
+Testing `test/e2e/alcotest/failing/invalid_arg_in_test.ml'.
 This run has ID `<uuid>'.
 
   [OK]          test-a          0   Passing.

--- a/test/e2e/alcotest/failing/invalid_arg_in_test.ml
+++ b/test/e2e/alcotest/failing/invalid_arg_in_test.ml
@@ -1,6 +1,6 @@
 let () =
   let open Alcotest in
-  run "suite-with-failures"
+  run __FILE__
     [
       ( "test-a",
         [

--- a/test/e2e/alcotest/failing/long_test_case_name.expected
+++ b/test/e2e/alcotest/failing/long_test_case_name.expected
@@ -1,4 +1,4 @@
-Testing `suite-with-failures'.
+Testing `test/e2e/alcotest/failing/long_test_case_name.ml'.
 This run has ID `<uuid>'.
 
   [OK]          test-a          0   Passing.

--- a/test/e2e/alcotest/failing/long_test_case_name.ml
+++ b/test/e2e/alcotest/failing/long_test_case_name.ml
@@ -1,6 +1,6 @@
 let () =
   let open Alcotest in
-  run "suite-with-failures"
+  run __FILE__
     [
       ( "test-a",
         [

--- a/test/e2e/alcotest/failing/tail_errors_limit.expected
+++ b/test/e2e/alcotest/failing/tail_errors_limit.expected
@@ -1,4 +1,4 @@
-Testing `tail_errors_limit'.
+Testing `test/e2e/alcotest/failing/tail_errors_limit.ml'.
 This run has ID `<uuid>'.
 
 > [FAIL]        failing          0   test.

--- a/test/e2e/alcotest/failing/tail_errors_limit.ml
+++ b/test/e2e/alcotest/failing/tail_errors_limit.ml
@@ -7,5 +7,5 @@ let test_error_output () =
 
 let () =
   let open Alcotest in
-  run ~tail_errors:(`Limit 10) "tail_errors_limit"
+  run ~tail_errors:(`Limit 10) __FILE__
     [ ("failing", [ test_case "test" `Quick test_error_output ]) ]

--- a/test/e2e/alcotest/failing/tail_errors_unlimited.expected
+++ b/test/e2e/alcotest/failing/tail_errors_unlimited.expected
@@ -1,4 +1,4 @@
-Testing `tail_errors_unlimited'.
+Testing `test/e2e/alcotest/failing/tail_errors_unlimited.ml'.
 This run has ID `<uuid>'.
 
 > [FAIL]        failing          0   test.

--- a/test/e2e/alcotest/failing/tail_errors_unlimited.ml
+++ b/test/e2e/alcotest/failing/tail_errors_unlimited.ml
@@ -6,5 +6,5 @@ let test_error_output () =
 
 let () =
   let open Alcotest in
-  run ~tail_errors:`Unlimited "tail_errors_unlimited"
+  run ~tail_errors:`Unlimited __FILE__
     [ ("failing", [ test_case "test" `Quick test_error_output ]) ]

--- a/test/e2e/alcotest/failing/unknown_option.ml
+++ b/test/e2e/alcotest/failing/unknown_option.ml
@@ -1,3 +1,3 @@
 let () =
-  Alcotest.run "unknown_option"
+  Alcotest.run __FILE__
     [ ("alpha", [ Alcotest.test_case "1" `Quick (fun () -> ()) ]) ]

--- a/test/e2e/alcotest/inside-dune/color-overridden.expected
+++ b/test/e2e/alcotest/inside-dune/color-overridden.expected
@@ -1,4 +1,4 @@
-Testing `test_color'.
+Testing `test/e2e/alcotest/inside-dune/test_color.ml'.
 This run has ID `<uuid>'.
 
   [OK]          alpha          0   Output may or may not contain ANSII escape codes.

--- a/test/e2e/alcotest/inside-dune/test_color.ml
+++ b/test/e2e/alcotest/inside-dune/test_color.ml
@@ -1,7 +1,7 @@
 let () =
   let open Alcotest in
   let id () = () in
-  run "test_color"
+  run __FILE__
     [
       ( "alpha",
         [

--- a/test/e2e/alcotest/passing/and_exit_false.expected
+++ b/test/e2e/alcotest/passing/and_exit_false.expected
@@ -1,4 +1,4 @@
-Testing `suite-name'.
+Testing `test/e2e/alcotest/passing/and_exit_false.ml'.
 This run has ID `<uuid>'.
 
   [OK]          test-a          0   Test case.

--- a/test/e2e/alcotest/passing/and_exit_false.ml
+++ b/test/e2e/alcotest/passing/and_exit_false.ml
@@ -1,6 +1,6 @@
 let () =
   let open Alcotest in
   let id () = () in
-  run ~and_exit:false "suite-name"
+  run ~and_exit:false __FILE__
     [ ("test-a", [ test_case "Test case" `Quick id ]) ];
   Printf.printf "\n Program execution continued!%!"

--- a/test/e2e/alcotest/passing/and_exit_true.expected
+++ b/test/e2e/alcotest/passing/and_exit_true.expected
@@ -1,4 +1,4 @@
-Testing `suite-name'.
+Testing `test/e2e/alcotest/passing/and_exit_true.ml'.
 This run has ID `<uuid>'.
 
   [OK]          test-a          0   Test case.

--- a/test/e2e/alcotest/passing/and_exit_true.ml
+++ b/test/e2e/alcotest/passing/and_exit_true.ml
@@ -1,7 +1,7 @@
 let () =
   let open Alcotest in
   let id () = () in
-  run ~and_exit:true "suite-name"
+  run ~and_exit:true __FILE__
     [ ("test-a", [ test_case "Test case" `Quick id ]) ];
   Printf.printf "\n Should never be printed!%!";
   assert false

--- a/test/e2e/alcotest/passing/assert_not_printed.expected
+++ b/test/e2e/alcotest/passing/assert_not_printed.expected
@@ -1,4 +1,4 @@
-Testing `assert-not-printed'.
+Testing `test/e2e/alcotest/passing/assert_not_printed.ml'.
 This run has ID `<uuid>'.
 
   [OK]          alpha          0   0.

--- a/test/e2e/alcotest/passing/assert_not_printed.ml
+++ b/test/e2e/alcotest/passing/assert_not_printed.ml
@@ -5,7 +5,7 @@
 let () =
   let open Alcotest in
   let s tc = tc ^ ": SHOULD NOT BE PRINTED" in
-  run "assert-not-printed"
+  run __FILE__
     [
       ( "alpha",
         [

--- a/test/e2e/alcotest/passing/basic.expected
+++ b/test/e2e/alcotest/passing/basic.expected
@@ -1,4 +1,4 @@
-Testing `suite-name'.
+Testing `test/e2e/alcotest/passing/basic.ml'.
 This run has ID `<uuid>'.
 
   [OK]          test-a          0   First test case.

--- a/test/e2e/alcotest/passing/basic.ml
+++ b/test/e2e/alcotest/passing/basic.ml
@@ -1,7 +1,7 @@
 let () =
   let open Alcotest in
   let id () = () in
-  run "suite-name"
+  run __FILE__
     [
       ( "test-a",
         [

--- a/test/e2e/alcotest/passing/check_basic.expected
+++ b/test/e2e/alcotest/passing/check_basic.expected
@@ -1,4 +1,4 @@
-Testing `passing testables'.
+Testing `test/e2e/alcotest/passing/check_basic.ml'.
 This run has ID `<uuid>'.
 
   [OK]          reflexive basic              0   unit.

--- a/test/e2e/alcotest/passing/check_basic.ml
+++ b/test/e2e/alcotest/passing/check_basic.ml
@@ -41,7 +41,7 @@ let labeled_check () = Alcotest.(check' int) ~msg:"Foo" ~expected:1 ~actual:1
 
 let () =
   let open Alcotest in
-  run "passing testables"
+  run __FILE__
     [
       ( "reflexive basic",
         [

--- a/test/e2e/alcotest/passing/compact.expected
+++ b/test/e2e/alcotest/passing/compact.expected
@@ -1,4 +1,4 @@
-Testing `compact'.
+Testing `test/e2e/alcotest/passing/compact.ml'.
 This run has ID `<uuid>'.
 
 ................................................................................

--- a/test/e2e/alcotest/passing/compact.ml
+++ b/test/e2e/alcotest/passing/compact.ml
@@ -3,7 +3,7 @@ open Alcotest_engine.Private.Utils
 let () =
   let open Alcotest in
   let id () = () in
-  run "compact"
+  run __FILE__
     [
       ( "test-a",
         List.init 200 (fun i ->

--- a/test/e2e/alcotest/passing/empty_test_name.expected
+++ b/test/e2e/alcotest/passing/empty_test_name.expected
@@ -1,4 +1,4 @@
-Testing `<suite-name>'.
+Testing `test/e2e/alcotest/passing/empty_test_name.ml'.
 This run has ID `<uuid>'.
 
   [OK]                    0   1.

--- a/test/e2e/alcotest/passing/empty_test_name.ml
+++ b/test/e2e/alcotest/passing/empty_test_name.ml
@@ -1,3 +1,3 @@
 let () =
-  Alcotest.run "<suite-name>"
+  Alcotest.run __FILE__
     [ ("", [ Alcotest.test_case "1" `Quick (fun () -> ()) ]) ]

--- a/test/e2e/alcotest/passing/filter_name.expected
+++ b/test/e2e/alcotest/passing/filter_name.expected
@@ -1,4 +1,4 @@
-Testing `suite-name'.
+Testing `test/e2e/alcotest/passing/filter_name.ml'.
 This run has ID `<uuid>'.
 
   [OK]          test-a          0   First test case.

--- a/test/e2e/alcotest/passing/filter_name.ml
+++ b/test/e2e/alcotest/passing/filter_name.ml
@@ -1,7 +1,7 @@
 let () =
   let open Alcotest in
   let id () = () in
-  run ~argv:[| ""; "test"; "test-a" |] "suite-name"
+  run ~argv:[| ""; "test"; "test-a" |] __FILE__
     [
       ( "test-a",
         [

--- a/test/e2e/alcotest/passing/filter_name_regex.expected
+++ b/test/e2e/alcotest/passing/filter_name_regex.expected
@@ -1,4 +1,4 @@
-Testing `suite-name'.
+Testing `test/e2e/alcotest/passing/filter_name_regex.ml'.
 This run has ID `<uuid>'.
 
   [OK]          basic-run-a            0   Executed.

--- a/test/e2e/alcotest/passing/filter_name_regex.ml
+++ b/test/e2e/alcotest/passing/filter_name_regex.ml
@@ -3,7 +3,7 @@ let () =
   let id () = () in
   run
     ~argv:[| ""; "test"; "basic-.*-(a|c)" |]
-    "suite-name"
+    __FILE__
     [
       ( "basic-run-a",
         [ test_case "Executed" `Quick id; test_case "Also executed" `Quick id ]

--- a/test/e2e/alcotest/passing/isatty.expected
+++ b/test/e2e/alcotest/passing/isatty.expected
@@ -1,4 +1,4 @@
-Testing `isatty'.
+Testing `test/e2e/alcotest/passing/isatty.ml'.
 This run has ID `<uuid>'.
 
   ...           test-a          0   First test case.  [OK]          test-a          0   First test case.

--- a/test/e2e/alcotest/passing/isatty.ml
+++ b/test/e2e/alcotest/passing/isatty.ml
@@ -13,7 +13,7 @@ module Alcotest =
 let () =
   let open Alcotest in
   let id () = () in
-  run "isatty"
+  run __FILE__
     [
       ( "test-a",
         [

--- a/test/e2e/alcotest/passing/json_output.expected
+++ b/test/e2e/alcotest/passing/json_output.expected
@@ -1,4 +1,4 @@
-Testing `suite-name'.
+Testing `test/e2e/alcotest/passing/json_output.ml'.
 This run has ID `<uuid>'.
 
 {

--- a/test/e2e/alcotest/passing/json_output.ml
+++ b/test/e2e/alcotest/passing/json_output.ml
@@ -1,7 +1,7 @@
 let () =
   let open Alcotest in
   let id () = () in
-  run ~argv:[| ""; "--json" |] "suite-name"
+  run ~argv:[| ""; "--json" |] __FILE__
     [
       ( "test-a",
         [

--- a/test/e2e/alcotest/passing/list_tests.ml
+++ b/test/e2e/alcotest/passing/list_tests.ml
@@ -1,7 +1,7 @@
 let () =
   let open Alcotest in
   let failtest () = invalid_arg "This test should never be run" in
-  run ~argv:[| ""; "list" |] "suite-name"
+  run ~argv:[| ""; "list" |] __FILE__
     [
       ( "test-a",
         [ test_case "alpha" `Quick failtest; test_case "beta" `Quick failtest ]

--- a/test/e2e/alcotest/passing/only_monadic_effects.ml
+++ b/test/e2e/alcotest/passing/only_monadic_effects.ml
@@ -28,7 +28,7 @@ module Runner = Alcotest_engine.Core.Make (Alcotest.Unix) (Terminal)
 
 let () =
   let (_ : unit Terminal.t) =
-    Runner.run ~verbose:true "event_ordering"
+    Runner.run ~verbose:true __FILE__
       [
         ( "alpha",
           [

--- a/test/e2e/alcotest/passing/quick_only.expected
+++ b/test/e2e/alcotest/passing/quick_only.expected
@@ -1,4 +1,4 @@
-Testing `suite-name'.
+Testing `test/e2e/alcotest/passing/quick_only.ml'.
 This run has ID `<uuid>'.
 
   [OK]          test-a          0   Quick.

--- a/test/e2e/alcotest/passing/quick_only.ml
+++ b/test/e2e/alcotest/passing/quick_only.ml
@@ -1,7 +1,7 @@
 let () =
   let open Alcotest in
   let id () = () in
-  run ~argv:[| ""; "--quick" |] "suite-name"
+  run ~argv:[| ""; "--quick" |] __FILE__
     [
       ("test-a", [ test_case "Quick" `Quick id; test_case "Slow" `Slow id ]);
       ("test-b", [ test_case "Slow" `Slow id; test_case "Quick" `Quick id ]);

--- a/test/e2e/alcotest/passing/quick_only_regex.expected
+++ b/test/e2e/alcotest/passing/quick_only_regex.expected
@@ -1,4 +1,4 @@
-Testing `suite-name'.
+Testing `test/e2e/alcotest/passing/quick_only_regex.ml'.
 This run has ID `<uuid>'.
 
   [OK]          test-a          0   Quick & passes filter.

--- a/test/e2e/alcotest/passing/quick_only_regex.ml
+++ b/test/e2e/alcotest/passing/quick_only_regex.ml
@@ -3,7 +3,7 @@ let () =
   let id () = () in
   run
     ~argv:[| ""; "test"; "--quick"; ".*-a" |]
-    "suite-name"
+    __FILE__
     [
       ( "test-a",
         [

--- a/test/e2e/alcotest/passing/separator_testname.expected
+++ b/test/e2e/alcotest/passing/separator_testname.expected
@@ -1,4 +1,4 @@
-Testing `suite-name'.
+Testing `test/e2e/alcotest/passing/separator_testname.ml'.
 This run has ID `<uuid>'.
 
   [OK]          with/separator          0   First test case.

--- a/test/e2e/alcotest/passing/separator_testname.ml
+++ b/test/e2e/alcotest/passing/separator_testname.ml
@@ -1,5 +1,5 @@
 let () =
-  Alcotest.run "suite-name"
+  Alcotest.run __FILE__
     [
       ( "with/separator",
         [ Alcotest.test_case "First test case" `Quick (fun () -> ()) ] );

--- a/test/e2e/alcotest/passing/verbose_newlines.expected
+++ b/test/e2e/alcotest/passing/verbose_newlines.expected
@@ -1,4 +1,4 @@
-Testing `suite-name'.
+Testing `test/e2e/alcotest/passing/verbose_newlines.ml'.
 This run has ID `<uuid>'.
 
 Print inside alpha  [OK]          alpha          0   0 newlines.

--- a/test/e2e/alcotest/passing/verbose_newlines.ml
+++ b/test/e2e/alcotest/passing/verbose_newlines.ml
@@ -2,7 +2,7 @@
     interaction between `--verbose` and newlines in the test stdout. *)
 
 let () =
-  Alcotest.run ~verbose:true "suite-name"
+  Alcotest.run ~verbose:true __FILE__
     [
       ( "alpha",
         [


### PR DESCRIPTION
This avoids a bug in which running the tests concurrently would occasionally result in spurious failures, due to different binaries attempting to write to the same log files.

Partial fix for https://github.com/mirage/alcotest/issues/272.