### PR TITLE
async: extract_exn

### DIFF
--- a/src/alcotest-async/alcotest_async.ml
+++ b/src/alcotest-async/alcotest_async.ml
@@ -11,7 +11,9 @@ module Tester =
       let bind x f = bind x ~f
 
       let catch t on_error =
-        try_with t >>= function Ok a -> return a | Error exn -> on_error exn
+        try_with ~extract_exn:true t >>= function
+        | Ok a -> return a
+        | Error exn -> on_error exn
     end)
 
 include Tester


### PR DESCRIPTION
This is need in order for the Async version to work properly.
Without it, `try_with` with not return the exception raised by user, but instead an exception wrapper which does not play nice with testing.