### PR TITLE
Preview of ocamlformat.0.16.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.15.0
+version = 0.16.0
 profile = conventional
 break-infix=fit-or-vertical
 parse-docstrings

--- a/src/alcotest-engine/cli.ml
+++ b/src/alcotest-engine/cli.ml
@@ -64,7 +64,7 @@ struct
             (* Default to [always] when running inside Dune *)
             let (_ : string) = Sys.getenv "INSIDE_DUNE" in
             Some `Ansi_tty
-          with Not_found -> None )
+          with Not_found -> None)
     in
     P.setup_std_outputs ?style_renderer ()
 
@@ -163,7 +163,7 @@ struct
           if n < 0 then
             Error (`Msg "numeric limit must be nonnegative or 'unlimited'")
           else Ok (`Limit n)
-        with Failure _ -> Error (`Msg "invalid numeric limit") )
+        with Failure _ -> Error (`Msg "invalid numeric limit"))
 
   let limit_printer ppf limit =
     match limit with

--- a/src/alcotest-engine/core.ml
+++ b/src/alcotest-engine/core.ml
@@ -81,7 +81,7 @@ struct
             let tail =
               String.Sub.to_string (String.sub ~start:(String.length home) path)
             in
-            "~" ^ tail )
+            "~" ^ tail)
 
   (* Types *)
   type return = unit M.t
@@ -267,14 +267,14 @@ struct
    fun args ->
     M.catch
       (fun () -> f args >|= fun () -> `Ok)
-      ( (function
-          | Check_error err ->
-              let err = Fmt.(err ++ const string (bt ())) in
-              `Error (path, err)
-          | Failure s -> exn path "failure" Fmt.(const string s)
-          | Invalid_argument s -> exn path "invalid" Fmt.(const string s)
-          | e -> exn path "exception" Fmt.(const exn e))
-      >> M.return )
+      ((function
+         | Check_error err ->
+             let err = Fmt.(err ++ const string (bt ())) in
+             `Error (path, err)
+         | Failure s -> exn path "failure" Fmt.(const string s)
+         | Invalid_argument s -> exn path "invalid" Fmt.(const string s)
+         | e -> exn path "exception" Fmt.(const exn e))
+      >> M.return)
 
   type running_state = { tests_so_far : int; prior_error : bool }
   (** State that is kept during the test executions. *)
@@ -404,7 +404,7 @@ struct
 
   let run_tests ?filter t () args =
     let suite = Suite.tests t.suite in
-    ( match filter with
+    (match filter with
     | None -> result t suite args
     | Some labels ->
         let is_empty = filter_test_cases ~subst:false labels suite = [] in
@@ -412,10 +412,10 @@ struct
           Fmt.(pf stderr)
             "%a\n" red
             "Invalid request (no tests to run, filter skipped everything)!";
-          exit 1 )
+          exit 1)
         else
           let tests = filter_test_cases ~subst:true labels suite in
-          result t tests args )
+          result t tests args)
     >|= fun result ->
     (pp_suite_results t) Fmt.stdout result;
     result.failures

--- a/src/alcotest-engine/pp.ml
+++ b/src/alcotest-engine/pp.ml
@@ -46,7 +46,7 @@ let left nb pp ppf a =
   if nb <= 0 then pp ppf a
   else (
     pp ppf a;
-    Fmt.string ppf (String.v ~len:nb (fun _ -> ' ')) )
+    Fmt.string ppf (String.v ~len:nb (fun _ -> ' ')))
 
 let pp_test_name ~max_label ppf tname =
   let name_len = Test_name.length tname in
@@ -104,8 +104,8 @@ let pp_result_compact ppf result =
 
 let left_padding ~with_selector =
   let open Fmt in
-  ( if with_selector then const (styled `Bold (styled `Red char)) '>'
-  else const char ' ' )
+  (if with_selector then const (styled `Bold (styled `Red char)) '>'
+  else const char ' ')
   ++ const char ' '
 
 let pp_result_full ~max_label ~doc_of_test_name ~selector_on_failure ppf
@@ -178,11 +178,11 @@ let with_surrounding_box (type a) (f : a Fmt.t) : a Fmt.t =
 
 let horizontal_rule (type a) ppf (_ : a) =
   let open Fmt in
-  ( const string " "
+  (const string " "
   ++ const
        (styled `Faint string)
        (List.init (terminal_width () - 2) (fun _ -> "─") |> String.concat)
-  ++ cut )
+  ++ cut)
     ppf ()
 
 let pp_full_logs ppf log_dir =
@@ -217,7 +217,7 @@ let suite_results ~verbose ~show_errors ~json ~compact ~log_dir ppf r =
       (pp_suite_errors ~show_all:(verbose || show_errors) r.errors) ppf ();
       if print_summary then (
         if not verbose then pp_full_logs ppf log_dir;
-        pp_summary ppf r );
+        pp_summary ppf r);
       Format.pp_close_box ppf ()
 
 let user_error msg =

--- a/src/alcotest-engine/utils.ml
+++ b/src/alcotest-engine/utils.ml
@@ -17,7 +17,7 @@ module List = struct
       | x :: xs -> (
           match f x with
           | None -> (inner [@tailcall]) acc xs
-          | Some y -> (inner [@tailcall]) (y :: acc) xs )
+          | Some y -> (inner [@tailcall]) (y :: acc) xs)
     in
     inner [] l
 

--- a/src/alcotest/alcotest.ml
+++ b/src/alcotest/alcotest.ml
@@ -16,10 +16,10 @@ module Unix (M : Alcotest_engine.Monad.S) = struct
         | [] -> ()
         | name :: names ->
             let path = parent ^ sep ^ name in
-            ( try Unix.mkdir path mode
-              with Unix.Unix_error (Unix.EEXIST, _, _) ->
-                if Sys.is_directory path then () (* the directory exists *)
-                else Fmt.strf "mkdir: %s: is a file" path |> failwith );
+            (try Unix.mkdir path mode
+             with Unix.Unix_error (Unix.EEXIST, _, _) ->
+               if Sys.is_directory path then () (* the directory exists *)
+               else Fmt.strf "mkdir: %s: is a file" path |> failwith);
             mk path names
       in
       match String.cuts ~empty:true ~sep path with
@@ -56,7 +56,7 @@ module Unix (M : Alcotest_engine.Monad.S) = struct
             retries target
         else (
           unlink_if_exists link_name;
-          inner ~retries:(retries + 1) )
+          inner ~retries:(retries + 1))
     in
     inner ~retries:0
 
@@ -69,7 +69,7 @@ module Unix (M : Alcotest_engine.Monad.S) = struct
         unlink_if_exists this_exe;
         unlink_if_exists latest;
         symlink ~to_dir:true ~target:dir ~link_name:this_exe;
-        symlink ~to_dir:true ~target:dir ~link_name:latest ) )
+        symlink ~to_dir:true ~target:dir ~link_name:latest))
     else if not (Sys.is_directory dir) then
       Fmt.failwith "exists but is not a directory: %S" dir
 


### PR DESCRIPTION
Hi, this pull-request is a preview of the soon to be released ocamlformat.0.16.0. The main change in the diff is that `indicate-multiline-delimiters` option has now be switched to `no` on the conventional profile to improve consistency and minimize the diffs in the future.
Let me now if you notice any regressions.