### PR TITLE
Don't pass `unit_m` to `Term.exit_status_of_result`

### DIFF
--- a/alcotest-async.opam
+++ b/alcotest-async.opam
@@ -10,6 +10,12 @@ doc: "https://mirage.github.io/alcotest"
 bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
   "dune" {>= "2.2"}
+  "re" {with-test}
+  "fmt" {with-test}
+  "cmdliner" {with-test}
+  "core"
+  "base"
+  "async_kernel"
   "ocaml" {>= "4.03.0"}
   "alcotest" {= version}
   "async_unix" {>= "v0.9.0"}

--- a/alcotest-lwt.opam
+++ b/alcotest-lwt.opam
@@ -10,6 +10,9 @@ doc: "https://mirage.github.io/alcotest"
 bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
   "dune" {>= "2.2"}
+  "re" {with-test}
+  "cmdliner" {with-test}
+  "fmt"
   "ocaml" {>= "4.03.0"}
   "alcotest" {= version}
   "lwt"

--- a/alcotest-mirage.opam
+++ b/alcotest-mirage.opam
@@ -10,6 +10,9 @@ doc: "https://mirage.github.io/alcotest"
 bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
   "dune" {>= "2.2"}
+  "re" {with-test}
+  "cmdliner" {with-test}
+  "fmt"
   "ocaml" {>= "4.03.0"}
   "alcotest" {= version}
   "mirage-clock" {>= "2.0.0"}

--- a/dune-project
+++ b/dune-project
@@ -39,6 +39,12 @@ tests to run.
  (description "Async-based helpers for Alcotest")
  (documentation "https://mirage.github.io/alcotest")
  (depends
+  (re :with-test)
+  (fmt :with-test)
+  (cmdliner :with-test)
+  core
+  base
+  async_kernel
   (ocaml (>= 4.03.0))
   (alcotest (= :version))
   (async_unix (>= v0.9.0))
@@ -50,6 +56,9 @@ tests to run.
  (description "Lwt-based helpers for Alcotest")
  (documentation "https://mirage.github.io/alcotest")
  (depends
+  (re :with-test)
+  (cmdliner :with-test)
+  fmt
   (ocaml (>= 4.03.0))
   (alcotest (= :version))
   lwt
@@ -61,6 +70,9 @@ tests to run.
  (description "Mirage implementation for Alcotest")
  (documentation "https://mirage.github.io/alcotest")
  (depends
+  (re :with-test)
+  (cmdliner :with-test)
+  fmt
   (ocaml (>= 4.03.0))
   (alcotest (= :version))
   (mirage-clock (>= 2.0.0))

--- a/examples/bad/dune
+++ b/examples/bad/dune
@@ -6,4 +6,5 @@
 
 (alias
  (name runtest)
+ (package alcotest)
  (deps bad.exe))

--- a/examples/dune
+++ b/examples/dune
@@ -1,3 +1,4 @@
 (tests
  (names simple floats)
+ (package alcotest)
  (libraries alcotest))

--- a/src/alcotest-engine/cli.ml
+++ b/src/alcotest-engine/cli.ml
@@ -323,9 +323,10 @@ struct
         choices
     in
     match result with
-    | `Ok unit_m -> unit_m >>= fun () -> exit_or_return result
-    | `Help | `Version | `Error `Exn -> exit_or_return result
-    | `Error (`Parse | `Term) -> exit (Term.exit_status_of_result result)
+    | `Ok unit_m -> unit_m >>= fun () -> exit_or_return (`Ok ())
+    | (`Help | `Version | `Error `Exn) as result -> exit_or_return result
+    | `Error (`Parse | `Term) as result ->
+        exit (Term.exit_status_of_result result)
 
   let run ?and_exit ?verbose ?compact ?tail_errors ?quick_only ?show_errors
       ?json ?filter ?log_dir ?argv name tl =

--- a/test/e2e/alcotest/failing/dune
+++ b/test/e2e/alcotest/failing/dune
@@ -17,5 +17,6 @@
 
 (rule
  (alias runtest)
+ (package alcotest)
  (action
   (diff dune.inc dune.gen)))

--- a/test/e2e/alcotest/passing/dune
+++ b/test/e2e/alcotest/passing/dune
@@ -17,5 +17,6 @@
 
 (rule
  (alias runtest)
+ (package alcotest)
  (action
   (diff dune.inc dune.gen)))


### PR DESCRIPTION
This only works because `exit_status_of_result` currently ignores the value passed, which is probably a bad idea.

See https://github.com/dbuenzli/cmdliner/pull/124.