### PR TITLE
Use Unix.gettimeofday rather than Unix.time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+- Correctly report test suite duration with millisecond precision. (#286,
+  @CraigFe)
+
 ### 1.2.3 (2020-09-07)
 
 - Require Dune 2.2. (#274, @CraigFe)

--- a/src/alcotest/alcotest.ml
+++ b/src/alcotest/alcotest.ml
@@ -31,7 +31,7 @@ module Unix (M : Alcotest_engine.Monad.S) = struct
 
   open M.Infix
 
-  let time = Unix.time
+  let time = Unix.gettimeofday
 
   let getcwd = Sys.getcwd
 

--- a/test/e2e/alcotest-lwt/passing/cli_options.expected
+++ b/test/e2e/alcotest-lwt/passing/cli_options.expected
@@ -4,5 +4,5 @@ This run has ID `<uuid>'.
 {
   "success": 1,
   "failures": 0,
-  "time": 0.000000
+  "time": <test-duration>
 }

--- a/test/e2e/alcotest/passing/json_output.expected
+++ b/test/e2e/alcotest/passing/json_output.expected
@@ -4,5 +4,5 @@ This run has ID `<uuid>'.
 {
   "success": 3,
   "failures": 0,
-  "time": 0.000000
+  "time": <test-duration>
 }


### PR DESCRIPTION
We print the duration of test suites to millisecond precision, so we should be using a time source with at least that precision.

It'd be more correct to use `mtime`, but this [doesn't yet support Windows](https://github.com/dbuenzli/mtime/issues/2).