### PR TITLE
Add triple testable for 3-elements tuple

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+- Add `Alcotest.triple` for testing 3-tuples. (#288, @sheepduke)
+
 - Correctly report test suite duration with millisecond precision. (#286,
   @CraigFe)
 

--- a/src/alcotest-engine/test.ml
+++ b/src/alcotest-engine/test.ml
@@ -96,6 +96,21 @@ let pair a b =
   let eq (a1, b1) (a2, b2) = equal a a1 a2 && equal b b1 b2 in
   testable (Fmt.Dump.pair (pp a) (pp b)) eq
 
+let triple a b c =
+  let eq (a1, b1, c1) (a2, b2, c2) =
+    equal a a1 a2 && equal b b1 b2 && equal c c1 c2
+  in
+  let pp =
+    Fmt.(
+      parens
+        (using (fun (x, _, _) -> x) (box (pp a))
+        ++ comma
+        ++ using (fun (_, x, _) -> x) (box (pp b))
+        ++ comma
+        ++ using (fun (_, _, x) -> x) (box (pp c))))
+  in
+  testable pp eq
+
 let option e =
   let eq x y =
     match (x, y) with

--- a/src/alcotest-engine/test.mli
+++ b/src/alcotest-engine/test.mli
@@ -84,6 +84,10 @@ val result : 'a testable -> 'e testable -> ('a, 'e) result testable
 val pair : 'a testable -> 'b testable -> ('a * 'b) testable
 (** [pair a b] tests pairs of [a]s and [b]s. *)
 
+val triple :
+  'a testable -> 'b testable -> 'c testable -> ('a * 'b * 'c) testable
+(** [triple a b c] tests triples of [a]s, [b]s and [c]s. *)
+
 val of_pp : 'a Fmt.t -> 'a testable
 (** [of_pp pp] tests values which can be printed using [pp] and compared using
     {!Pervasives.compare} *)

--- a/test/e2e/alcotest/failing/check_basic.expected
+++ b/test/e2e/alcotest/failing/check_basic.expected
@@ -27,6 +27,8 @@ ASSERT result
   [FAIL]        different composite          3   result.
 ASSERT pair
   [FAIL]        different composite          4   pair.
+ASSERT triple
+  [FAIL]        different composite          5   triple.
 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        different basic              0   bool.                         │
@@ -157,4 +159,14 @@ FAIL pair
    Received: `(1, b)'
  ──────────────────────────────────────────────────────────────────────────────
 
-13 failures! in <test-duration>s. 13 tests run.
+
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [FAIL]        different composite          5   triple.                       │
+└──────────────────────────────────────────────────────────────────────────────┘
+FAIL triple
+
+   Expected: `(1, true, a)'
+   Received: `(1, false, a)'
+ ──────────────────────────────────────────────────────────────────────────────
+
+14 failures! in <test-duration>s. 14 tests run.

--- a/test/e2e/alcotest/failing/check_basic.ml
+++ b/test/e2e/alcotest/failing/check_basic.ml
@@ -28,5 +28,7 @@ let () =
           id_case (option int) "option some" (Some 1) (Some 2);
           id_case (result int unit) "result" (Ok 1) (Error ());
           id_case (pair int char) "pair" (1, 'a') (1, 'b');
+          id_case (triple int bool string) "triple" (1, true, "a")
+            (1, false, "a");
         ] );
     ]

--- a/test/e2e/alcotest/passing/check_basic.expected
+++ b/test/e2e/alcotest/passing/check_basic.expected
@@ -19,6 +19,7 @@ This run has ID `<uuid>'.
   [OK]          reflexive composite          6   result ok.
   [OK]          reflexive composite          7   result error.
   [OK]          reflexive composite          8   pair.
+  [OK]          reflexive composite          9   triple.
   [OK]          negation                     0   checked exceptions.
   [OK]          negation                     1   negated testables.
   [OK]          fuzzy equality               0   float thresholds.
@@ -26,4 +27,4 @@ This run has ID `<uuid>'.
   [OK]          labeled check                0   passing.
 
 Full test results in `<build-context>/_build/_tests/<test-dir>'.
-Test Successful in <test-duration>s. 23 tests run.
+Test Successful in <test-duration>s. 24 tests run.

--- a/test/e2e/alcotest/passing/check_basic.ml
+++ b/test/e2e/alcotest/passing/check_basic.ml
@@ -66,6 +66,7 @@ let () =
           id_case (result int unit) "result ok" (Ok 1);
           id_case (result int unit) "result error" (Error ());
           id_case (pair int char) "pair" (1, 'a');
+          id_case (triple int bool string) "triple" (1, true, "a");
         ] );
       ( "negation",
         [


### PR DESCRIPTION
Add a new testable `triple` that is very similar to `pair`.

Resolves #288.