### PR TITLE
Don't print empty assertions

### DIFF
--- a/test/e2e/alcotest/failing/outside_runner.ml
+++ b/test/e2e/alcotest/failing/outside_runner.ml
@@ -2,5 +2,6 @@
     [Alcotest.run]. *)
 
 let () =
+  Alcotest.(check int) "" 1 1 (* Empty passing assertion; should be silent *);
   Alcotest.(check int) "Passing assertion" 1 1;
   Alcotest.(check int) "Failing assertion" 1 2


### PR DESCRIPTION
This ensures that passing assertions with an empty message are silent, which is probably the correct behaviour.