### PR TITLE
alcotest.opam: add lower bound on cmdliner

### DIFF
--- a/alcotest.opam
+++ b/alcotest.opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "fmt" {>= "0.8.7"}
   "astring"
-  "cmdliner"
+  "cmdliner" {>= "1.0.0"}
   "uuidm"
   "re"
   "stdlib-shims"

--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@ tests to run.
   (ocaml (>= 4.03.0))
   (fmt (>= 0.8.7))
   astring
-  cmdliner
+  (cmdliner (>= 1.0.0))
   uuidm
   re
   stdlib-shims


### PR DESCRIPTION
The Ocaml CI sometimes fails with `Unbound value Cmdliner.Arg.conv`, which was introduced in version 1.0.0