### PR TITLE
Extract Log_trap abstraction and cleanup log handling

### DIFF
--- a/src/alcotest-engine/core.ml
+++ b/src/alcotest-engine/core.ml
@@ -54,21 +54,8 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
 
   module M = Monad.Extend (M)
   module Suite = Suite (M)
+  module Log_trap = Log_trap.Make (M) (P)
   include M.Infix
-
-  (** Take a string path and collapse a leading [$HOME] path segment to [~]. *)
-  let maybe_collapse_home path =
-    match P.home_directory () with
-    | Error _ -> path
-    | Ok home -> (
-        (* Astring doesn't have [cut_prefix]. *)
-        match String.is_prefix ~affix:home path with
-        | false -> path
-        | true ->
-            let tail =
-              String.Sub.to_string (String.sub ~start:(String.length home) path)
-            in
-            "~" ^ tail)
 
   (* Types *)
   type return = unit M.t
@@ -94,12 +81,13 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
         (** Longest test label in the suite, in UTF-8 characters. *)
     config : Config.t;
     run_id : string;
+    log_trap : Log_trap.t;
   }
 
-  let empty ~config ~suite_name =
+  let empty ~config ~suite_name:unescaped_name =
     let errors = [] in
     let suite =
-      match Suite.v ~name:suite_name with
+      match Suite.v ~name:unescaped_name with
       | Ok s -> s
       | Error `Empty_name ->
           Pp.user_error
@@ -107,8 +95,18 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
              to `run`."
     in
     let max_label = 0 in
-    let run_id = Uuidm.to_string ~upper:true Uuidm.nil in
-    { suite; errors; max_label; config; run_id }
+    let run_id =
+      let random_state = Random.State.make_self_init () in
+      Uuidm.v4_gen random_state () |> Uuidm.to_string ~upper:true
+    in
+    let log_trap =
+      match config#verbose with
+      | true -> Log_trap.inactive
+      | false ->
+          Log_trap.active ~root:config#log_dir ~uuid:run_id
+            ~suite_name:(Suite.name suite)
+    in
+    { suite; errors; max_label; config; run_id; log_trap }
 
   let compare_speed_level s1 s2 =
     match (s1, s2) with
@@ -116,55 +114,8 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
     | `Quick, _ -> 1
     | _, `Quick -> -1
 
-  (*
-     Reverse a list, taking at most the first n elements of the original
-     list.
-  *)
-  let rev_head n l =
-    let rec aux acc n l =
-      match l with
-      | x :: xs -> if n > 0 then aux (x :: acc) (n - 1) xs else acc
-      | [] -> acc
-    in
-    aux [] n l
-
-  (*
-     Show the last lines of a log file.
-     The goal is to not clutter up the console output.
-  *)
-  let read_tail max_lines ic =
-    let rev_lines = ref [] in
-    try
-      while true do
-        rev_lines := input_line ic :: !rev_lines
-      done;
-      assert false
-    with End_of_file ->
-      let selected_lines =
-        match max_lines with
-        | `Unlimited -> List.rev !rev_lines
-        | `Limit n -> rev_head n !rev_lines
-      in
-      let omitted_count = List.length !rev_lines - List.length selected_lines in
-      let display_lines =
-        if omitted_count = 0 then selected_lines
-        else
-          Fmt.strf "... (omitting %i line%a)" omitted_count Pp.pp_plural
-            omitted_count
-          :: selected_lines
-      in
-      String.concat ~sep:"\n" display_lines ^ "\n"
-
-  let log_dir ~via_symlink t =
-    let via_symlink =
-      (* We don't create symlinks on Windows. *)
-      via_symlink && not Sys.win32
-    in
-    Filename.concat t.config#log_dir
-      (if via_symlink then Suite.name t.suite else t.run_id)
-
   let pp_suite_results t =
-    let log_dir = log_dir ~via_symlink:true t |> maybe_collapse_home in
+    let log_dir = Log_trap.pp_current_run_dir t.log_trap in
     Pp.suite_results ~log_dir t.config
 
   let pp_event ~isatty ~prior_error ~tests_so_far t =
@@ -182,33 +133,33 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
     Pp.info ~max_label:t.max_label
       ~doc_of_test_name:(Suite.doc_of_test_name t.suite)
 
-  let output_file t tname =
-    Filename.concat (log_dir ~via_symlink:true t) (Test_name.file tname)
-
   let color c ppf fmt = Fmt.(styled c string) ppf fmt
   let red_s fmt = color `Red fmt
   let red ppf fmt = Fmt.kstrf (fun str -> red_s ppf str) fmt
 
-  let pp_error ~doc_of_test_name ~output_file ~max_label cfg ppf e =
+  let pp_error t ppf e =
     let path, error_fmt =
       match e with `Error (p, f) -> (p, f) | `Exn (p, _, f) -> (p, f)
     in
     let pp_logs ppf () =
-      let filename = output_file path in
-      if cfg#verbose || not (Sys.file_exists filename) then
-        Fmt.pf ppf "%a@," error_fmt ()
-      else
-        let file = open_in filename in
-        let output = read_tail cfg#tail_errors file in
-        close_in file;
-        Fmt.pf ppf "%s@,Logs saved to %a.@," output
-          Fmt.(Pp.quoted (styled `Cyan string))
-          (maybe_collapse_home filename)
+      let pp_logs =
+        Log_trap.recover_logs ~tail:t.config#tail_errors t.log_trap path
+      in
+      match (t.config#verbose, pp_logs) with
+      | true, _ | _, None -> Fmt.pf ppf "%a@," error_fmt ()
+      | false, Some pp_logs ->
+          let pp_log_dir =
+            Pp.map_theta
+              ~f:(fun s -> Pp.quoted (Fmt.styled `Cyan s))
+              (Log_trap.pp_log_location t.log_trap path)
+          in
+          Fmt.pf ppf "%t@,Logs saved to %t.@," pp_logs pp_log_dir
     in
     Fmt.(
       Pp.with_surrounding_box
         (const
-           (Pp.event_line ~margins:3 ~max_label ~doc_of_test_name)
+           (Pp.event_line ~margins:3 ~max_label:t.max_label
+              ~doc_of_test_name:(Suite.doc_of_test_name t.suite))
            (`Result (path, e)))
       ++ pp_logs
       ++ Pp.horizontal_rule
@@ -238,37 +189,52 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
   type running_state = { tests_so_far : int; first_error : int option }
   (** State that is kept during the test executions. *)
 
-  let perform_test t args { tests_so_far; first_error } suite =
+  let with_captured_logs t name fn args =
+    if t.config#verbose then fn args
+    else
+      Log_trap.with_captured_logs t.log_trap name
+        (fun () ->
+          (* When capturing the logs of a test, also add the result of the test
+             at the end. *)
+          fn args >|= fun result ->
+          Pp.rresult_error Fmt.stdout result;
+          result)
+        ()
+
+  let perform_test t args { tests_so_far; first_error }
+      (test : _ Suite.test_case) =
     let open Suite in
-    let test = suite.fn in
     let print_event =
       pp_event t
         ~prior_error:(Option.is_some first_error)
         ~tests_so_far ~isatty:(P.stdout_isatty ()) Fmt.stdout
     in
     M.return () >>= fun () ->
-    print_event (`Start suite.name);
-    Fmt.(flush stdout) () (* Show event before any test stderr *);
-    test args >|= fun result ->
-    (* Store errors *)
-    let errored : bool =
-      let pp_error =
-        pp_error
-          ~doc_of_test_name:(Suite.doc_of_test_name t.suite)
-          ~output_file:(output_file t) ~max_label:t.max_label t.config
-      in
-      let error, errored =
-        match result with
-        | (`Error _ | `Exn (_, _, _)) as e -> ([ Fmt.const pp_error e ], true)
-        | _ -> ([], false)
-      in
-      t.errors <- error @ t.errors;
-      errored
+    print_event (`Start test.name);
+    let test_complete =
+      match test.fn with
+      | `Skip -> M.return (`Skip, false)
+      | `Run fn ->
+          Fmt.(flush stdout) () (* Show event before any test stderr *);
+          with_captured_logs t test.name fn args >|= fun result ->
+          (* Store errors *)
+          let errored : bool =
+            let error, errored =
+              match result with
+              | (`Error _ | `Exn (_, _, _)) as e ->
+                  ([ Fmt.const (pp_error t) e ], true)
+              | _ -> ([], false)
+            in
+            t.errors <- error @ t.errors;
+            errored
+          in
+          (* Show any remaining test output before the event *)
+          Fmt.(flush stdout ());
+          Fmt.(flush stderr ());
+          (result, errored)
     in
-    (* Show any remaining test output before the event *)
-    Fmt.(flush stdout ());
-    Fmt.(flush stderr ());
-    print_event (`Result (suite.name, result));
+    test_complete >|= fun (result, errored) ->
+    print_event (`Result (test.name, result));
     let error = if errored then Some tests_so_far else None in
     let state =
       {
@@ -302,8 +268,7 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
     in
     test_results
 
-  let skip_fun _ = M.return `Skip
-  let skip_label test_case = Suite.{ test_case with fn = skip_fun }
+  let skip_label test_case = Suite.{ test_case with fn = `Skip }
 
   let filter_test_case (regexp, cases) =
     let regexp_match =
@@ -333,28 +298,12 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
            else if subst then Some (skip_label tc)
            else None)
 
-  let redirect_test_output t test_case =
-    let output_file = output_file t test_case.Suite.name in
-    let fn args =
-      P.with_redirect output_file (fun () ->
-          test_case.fn args >|= fun result ->
-          Pp.rresult_error Fmt.stdout result;
-          result)
-    in
-    { test_case with fn }
-
   let select_speed speed_level (test_case : 'a Suite.test_case as 'tc) : 'tc =
     if compare_speed_level test_case.speed_level speed_level >= 0 then test_case
-    else Suite.{ test_case with fn = skip_fun }
+    else Suite.{ test_case with fn = `Skip }
 
   let result t test args =
-    P.prepare ~base:t.config#log_dir
-      ~dir:(log_dir ~via_symlink:false t)
-      ~name:(Suite.name t.suite);
     let start_time = P.time () in
-    let test =
-      if t.config#verbose then test else List.map (redirect_test_output t) test
-    in
     let speed_level = if t.config#quick_only then `Quick else `Slow in
     let test = List.map (select_speed speed_level) test in
     perform_tests t test args >|= fun results ->
@@ -380,7 +329,7 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
             else doc ^ "."
           in
           let test a = protect_test path test a in
-          (path, doc, speed, test))
+          (path, doc, speed, `Run test))
         ts
     in
     let suite =
@@ -433,9 +382,7 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
     let config =
       Config.apply_defaults ~default_log_dir:(default_log_dir ()) config
     in
-    let random_state = Random.State.make_self_init () in
-    let run_id = Uuidm.v4_gen random_state () |> Uuidm.to_string ~upper:true in
-    let t = { (empty ~config ~suite_name:name) with run_id } in
+    let t = empty ~config ~suite_name:name in
     let t = register_all t tl in
     ( (* Only print inside the concurrency monad *)
       M.return () >>= fun () ->
@@ -443,7 +390,7 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
       pr "Testing %a.@," (Pp.quoted Fmt.(styled `Bold Suite.pp_name)) t.suite;
       pr "@[<v>%a@]"
         (styled `Faint (fun ppf () ->
-             pf ppf "This run has ID %a.@,@," (Pp.quoted string) run_id))
+             pf ppf "This run has ID %a.@,@," (Pp.quoted string) t.run_id))
         ();
       run_tests t () args )
     >|= fun test_failures ->

--- a/src/alcotest-engine/log_trap.ml
+++ b/src/alcotest-engine/log_trap.ml
@@ -7,7 +7,7 @@ module Make
     (Promise : Monad.EXTENDED)
     (Platform : Platform.S with type 'a promise := 'a Promise.t) =
 struct
-  open Promise.Infix
+  open Promise.Syntax
 
   type state = { root : string; uuid : string; suite_name : string }
   type t = Inactive | Active of state
@@ -97,8 +97,8 @@ struct
     | Inactive -> f x
     | Active t ->
         let fd = Platform.open_write_only (output_fpath t tname) in
-        Promise.return () >>= fun () ->
-        Platform.with_redirect fd (fun () -> f x) >|= fun a ->
+        let* () = Promise.return () in
+        let+ a = Platform.with_redirect fd (fun () -> f x) in
         Platform.close fd;
         a
 end

--- a/src/alcotest-engine/log_trap.ml
+++ b/src/alcotest-engine/log_trap.ml
@@ -1,0 +1,104 @@
+open Astring
+open Model
+open Utils
+include Log_trap_intf
+
+module Make
+    (Promise : Monad.EXTENDED)
+    (Platform : Platform.S with type 'a promise := 'a Promise.t) =
+struct
+  open Promise.Infix
+
+  type state = { root : string; uuid : string; suite_name : string }
+  type t = Inactive | Active of state
+
+  (** Take a string path and collapse a leading [$HOME] path segment to [~]. *)
+  let maybe_collapse_home path =
+    match Platform.home_directory () with
+    | Error _ -> path
+    | Ok home -> (
+        (* Astring doesn't have [cut_prefix]. *)
+        match String.is_prefix ~affix:home path with
+        | false -> path
+        | true ->
+            let tail =
+              String.Sub.to_string (String.sub ~start:(String.length home) path)
+            in
+            "~" ^ tail)
+
+  let inactive = Inactive
+
+  let active ~root ~uuid ~suite_name =
+    Platform.prepare_log_trap ~root ~uuid ~name:suite_name;
+    Active { root; uuid; suite_name }
+
+  let pp_path = Fmt.using maybe_collapse_home Fmt.string
+
+  let iter_lines fpath ~f =
+    let ic = open_in fpath in
+    try
+      while true do
+        f (input_line ic)
+      done;
+      assert false
+    with End_of_file -> close_in ic
+
+  (** Show the last lines of a log file. *)
+  let pp_tail max_lines fpath ppf =
+    match max_lines with
+    | `Unlimited -> iter_lines fpath ~f:(Fmt.pf ppf "%s@\n")
+    | `Limit limit ->
+        let rev_lines = ref [] in
+        iter_lines fpath ~f:(fun l -> rev_lines := l :: !rev_lines);
+        let selected_lines = List.rev_head limit !rev_lines in
+        let omitted_count =
+          List.length !rev_lines - List.length selected_lines
+        in
+        let display_lines =
+          if omitted_count = 0 then selected_lines
+          else
+            Fmt.strf "... (omitting %i line%a)" omitted_count Pp.pp_plural
+              omitted_count
+            :: selected_lines
+        in
+        ListLabels.iter display_lines ~f:(Fmt.pf ppf "%s@\n")
+
+  let log_dir { suite_name; uuid; root } =
+    (* We don't create symlinks on Windows. *)
+    let via_symlink = not Sys.win32 in
+    Filename.concat root (if via_symlink then suite_name else uuid)
+
+  let output_fpath t tname = Filename.concat (log_dir t) (Test_name.file tname)
+
+  let active_or_exn = function
+    | Active t -> t
+    | Inactive -> failwith "internal error: no log location"
+
+  let pp_current_run_dir t ppf =
+    let t = active_or_exn t in
+    pp_path ppf (log_dir t)
+
+  let pp_log_location t tname ppf =
+    let t = active_or_exn t in
+    let path = output_fpath t tname in
+    pp_path ppf path
+
+  let recover_logs t ~tail tname =
+    match t with
+    | Inactive -> None
+    | Active t -> (
+        let fpath = output_fpath t tname in
+        match Platform.file_exists fpath with
+        | false -> None
+        | true -> Some (fun ppf -> pp_tail tail fpath ppf))
+
+  let with_captured_logs t tname f x =
+    match t with
+    | Inactive -> f x
+    | Active t ->
+        let fd = Platform.open_write_only (output_fpath t tname) in
+        Promise.return () >>= fun () ->
+        Platform.with_redirect fd (fun () -> f x) >|= fun a ->
+        Platform.close fd;
+        a
+end

--- a/src/alcotest-engine/log_trap.mli
+++ b/src/alcotest-engine/log_trap.mli
@@ -1,0 +1,2 @@
+include Log_trap_intf.Log_trap
+(** @inline *)

--- a/src/alcotest-engine/log_trap_intf.ml
+++ b/src/alcotest-engine/log_trap_intf.ml
@@ -1,0 +1,56 @@
+open Model
+
+(** Running tests have their output hidden by default to avoid cluttering the
+    Alcotest display with irrelevant output. However, we (usually) want to keep
+    the logs on disk so that we can re-display them if a test fails. Logs are
+    stored with the following structure:
+
+    {[
+      <log_capture_root_dir>
+      ├── E0965BF9-.../...
+      ├── 6DDB68D5-.../             ;; UUID for each test run
+      │   │
+      │   ├── alpha.000.output      ;; ... containing files for individual tests
+      │   ├── alpha.001.output      ;;     with format <test_name>.<index>.output.
+      │   └── beta.000.output
+      │
+      ├── latest/                   ;; Symlink to most recent UUID
+      └── <suite_name>/             ;; Symlink to most recent <suite_name> UUID
+    ]} *)
+module type S = sig
+  type 'a promise
+  type t
+
+  val inactive : t
+  val active : root:string -> uuid:string -> suite_name:string -> t
+
+  val with_captured_logs :
+    t -> Test_name.t -> ('a -> 'b promise) -> 'a -> 'b promise
+  (** Capture all logs for a given test run. *)
+
+  val recover_logs :
+    t ->
+    tail:[ `Unlimited | `Limit of int ] ->
+    Test_name.t ->
+    (Format.formatter -> unit) option
+  (** Print the logs for a given test to the given formatter, if they exist.
+      [tail] determines whether to show all lines in the captured log or just a
+      suffix of them. *)
+
+  val pp_current_run_dir : t -> Format.formatter -> unit
+  (** Print the folder containing all captured traces for the current test run.
+      Raises an exception if traces are not being recorded. *)
+
+  val pp_log_location : t -> Test_name.t -> Format.formatter -> unit
+  (** Print the file containing the trace of a particular test. Raises an
+      exception if traces are not being recorded. *)
+end
+
+module type Log_trap = sig
+  module type S = S
+
+  module Make
+      (Promise : Monad.EXTENDED)
+      (Platform : Platform.S with type 'a promise := 'a Promise.t) :
+    S with type 'a promise := 'a Promise.t
+end

--- a/src/alcotest-engine/model.ml
+++ b/src/alcotest-engine/model.ml
@@ -81,11 +81,12 @@ end
 
 module Suite (M : Monad.S) : sig
   type 'a t
+  type 'a test_fn = [ `Skip | `Run of 'a -> Run_result.t M.t ]
 
   type 'a test_case = {
     name : Test_name.t;
     speed_level : speed_level;
-    fn : 'a -> Run_result.t M.t;
+    fn : 'a test_fn;
   }
 
   val v : name:string -> (_ t, [> `Empty_name ]) result
@@ -100,7 +101,7 @@ module Suite (M : Monad.S) : sig
 
   val add :
     'a t ->
-    Test_name.t * string * speed_level * ('a -> Run_result.t M.t) ->
+    Test_name.t * string * speed_level * 'a test_fn ->
     ('a t, [ `Duplicate_test_path of string ]) result
 
   val tests : 'a t -> 'a test_case list
@@ -108,10 +109,12 @@ module Suite (M : Monad.S) : sig
 end = struct
   module String_set = Set.Make (String)
 
+  type 'a test_fn = [ `Skip | `Run of 'a -> Run_result.t M.t ]
+
   type 'a test_case = {
     name : Test_name.t;
     speed_level : speed_level;
-    fn : 'a -> Run_result.t M.t;
+    fn : 'a test_fn;
   }
 
   type 'a t = {

--- a/src/alcotest-engine/model.ml
+++ b/src/alcotest-engine/model.ml
@@ -3,7 +3,7 @@ open Utils
 type speed_level = [ `Quick | `Slow ]
 
 (** Given a UTF-8 encoded string, escape any characters not considered
-    "filesystem safe" as their [U+XXXX] notation form. *)
+    "filesystem safe" as their [U+XXXX] notation form (or using [-]). *)
 let escape str =
   let add_codepoint buf uchar =
     Uchar.to_int uchar |> Fmt.str "U+%04X" |> Buffer.add_string buf
@@ -17,6 +17,7 @@ let escape str =
           | ('A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '-' | ' ' | '.') as c
             ->
               Buffer.add_char buf c
+          | '/' | '\\' -> Buffer.add_char buf '-'
           | _ -> add_codepoint buf u
         else add_codepoint buf u
     | `Malformed _ -> Uutf.Buffer.add_utf_8 buf Uutf.u_rep

--- a/src/alcotest-engine/monad.ml
+++ b/src/alcotest-engine/monad.ml
@@ -27,19 +27,21 @@ end
 module Extend (M : S) = struct
   include M
 
-  module Infix = struct
+  module Syntax = struct
     let ( >>= ) = M.bind
     let ( >|= ) x f = x >>= fun y -> M.return (f y)
+    let ( let* ) = ( >>= )
+    let ( let+ ) = ( >|= )
   end
 
-  open Infix
+  open Syntax
 
   module List = struct
     let fold_map_s f init l =
       let rec inner acc results = function
         | [] -> M.return (acc, List.rev results)
         | hd :: tl ->
-            f acc hd >>= fun (acc, r) ->
+            let* acc, r = f acc hd in
             (inner [@ocaml.tailcall]) acc (r :: results) tl
       in
       inner init [] l

--- a/src/alcotest-engine/monad_intf.ml
+++ b/src/alcotest-engine/monad_intf.ml
@@ -25,7 +25,9 @@ end
 module type EXTENDED = sig
   include S
 
-  module Infix : sig
+  module Syntax : sig
+    val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
+    val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
     val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
     val ( >|= ) : 'a t -> ('a -> 'b) -> 'b t
   end

--- a/src/alcotest-engine/platform.ml
+++ b/src/alcotest-engine/platform.ml
@@ -6,13 +6,6 @@ module type S = sig
   val getcwd : unit -> string
   (** [getcwd ()] returns the current working directory. *)
 
-  val prepare : base:string -> dir:string -> name:string -> unit
-  (** [prepare ~base ~dir ~name] is called before test suite execution. [base]
-      is the parent of the log directory, [dir] the log directory (including
-      unique testrun ID), and [name] is the test name. On Unix, this function
-      creates the log directory [dir] for the test output, and sets up the
-      symlink [latest] to the latest result. *)
-
   type 'a promise
   (** The type of monadic actions handled by {!with_redirect}. *)
 
@@ -24,16 +17,31 @@ module type S = sig
   (** [stdout_columns ()] is the current width of [stdout] in columns, or [None]
       if no width can be determined (e.g. [stdout] is not a TTY). *)
 
-  val with_redirect : string -> (unit -> 'a promise) -> 'a promise
-  (** [with_redirect output_file f] is called for each test. On Unix, it it
-      deals with redirection of standard streams to the [output_file]. The
-      implementation of [with_redirect] has to make sure to call [f] in order to
-      run the test case. *)
-
   val setup_std_outputs :
     ?style_renderer:Fmt.style_renderer -> ?utf_8:bool -> unit -> unit
   (** [setup_std_outputs ~style_renderer ~utf_8 ()] is called at startup of
       alcotest and sets up the standard streams for colored output. *)
+
+  val log_trap_supported : bool
+  (** Whether or not the test runner should trap test logs. The following
+      functions are used iff this is set to [true]. *)
+
+  val prepare_log_trap : root:string -> uuid:string -> name:string -> unit
+  (** [prepare ~root ~uuid ~name] is called before test suite execution.
+
+      - [root] is the directory used for log capturing;
+      - [uuid] is the unique test execution ID;
+      - [name] is the suite name. *)
+
+  type file_descriptor
+
+  val file_exists : string -> bool
+  val open_write_only : string -> file_descriptor
+  val close : file_descriptor -> unit
+
+  val with_redirect : file_descriptor -> (unit -> 'a promise) -> 'a promise
+  (** [with_redirect fd f] is called for each test. On Unix, it deals with
+      redirection of standard streams to the [fd]. *)
 
   val home_directory : unit -> (string, [ `Msg of string ]) result
   (** [home_directory ()] is the current user's HOME directory, if it exists. *)

--- a/src/alcotest-engine/pp.ml
+++ b/src/alcotest-engine/pp.ml
@@ -20,6 +20,9 @@ include Pp_intf.Types
 open Model
 open Utils
 
+let map_theta t ~f ppf = f (fun ppf () -> t ppf) ppf ()
+let pp_plural ppf x = Fmt.pf ppf (if x < 2 then "" else "s")
+
 let colour_of_tag = function
   | `Ok -> `Green
   | `Fail -> `Red
@@ -170,7 +173,6 @@ struct
     | [] -> Fmt.nop
     | x :: _ as xs -> (if show_all then xs else [ x ]) |> Fmt.concat
 
-  let pp_plural ppf x = Fmt.pf ppf (if x < 2 then "" else "s")
   let quoted f = Fmt.(const char '`' ++ f ++ const char '\'')
 
   let with_surrounding_box (type a) (f : a Fmt.t) : a Fmt.t =
@@ -201,9 +203,8 @@ struct
       ppf ()
 
   let pp_full_logs ppf log_dir =
-    Fmt.pf ppf "Full test results in %a.@,"
-      Fmt.(quoted (styled `Cyan string))
-      log_dir
+    Fmt.pf ppf "Full test results in %t.@,"
+      (map_theta ~f:Fmt.(styled `Cyan >> quoted) log_dir)
 
   let pp_summary ppf r =
     let pp_failures ppf = function

--- a/src/alcotest-engine/pp_intf.ml
+++ b/src/alcotest-engine/pp_intf.ml
@@ -17,6 +17,9 @@
 
 open Model
 
+type theta = Format.formatter -> unit
+(** Type corresponding to a [%t] placeholder. *)
+
 module Types = struct
   type event = [ `Result of Test_name.t * Run_result.t | `Start of Test_name.t ]
 
@@ -56,7 +59,7 @@ module type S = sig
     event Fmt.t
 
   val suite_results :
-    log_dir:string ->
+    log_dir:theta ->
     < verbose : bool ; show_errors : bool ; json : bool ; compact : bool ; .. > ->
     result Fmt.t
 
@@ -71,14 +74,6 @@ module type S = sig
   (** Horizontal rule of length {!terminal_width}. Uses box-drawing characters
       from code page 437. *)
 
-  val pp_plural : int Fmt.t
-  (** This is for adding an 's' to words that should be pluralized, e.g.
-
-      {[
-        let n = List.length items in
-        Fmt.pr "Found %i item%a." n pp_plural n
-      ]} *)
-
   val user_error : string -> _
   (** Raise a user error, then fail. *)
 end
@@ -91,6 +86,15 @@ module type Pp = sig
   include module type of Types
 
   val tag : [ `Ok | `Fail | `Skip | `Todo | `Assert ] Fmt.t
+  val map_theta : theta -> f:(unit Fmt.t -> unit Fmt.t) -> theta
+
+  val pp_plural : int Fmt.t
+  (** This is for adding an 's' to words that should be pluralized, e.g.
+
+      {[
+        let n = List.length items in
+        Fmt.pr "Found %i item%a." n pp_plural n
+      ]} *)
 
   module Make (X : Make_arg) :
     S with type event := event and type result := result

--- a/src/alcotest-engine/utils.ml
+++ b/src/alcotest-engine/utils.ml
@@ -1,5 +1,9 @@
 let ( >> ) f g x = x |> f |> g
 
+module Fun = struct
+  let id x = x
+end
+
 module String = struct
   include Astring.String
 
@@ -23,6 +27,15 @@ module List = struct
   include List
 
   type 'a t = 'a list
+
+  let rev_head n l =
+    let rec aux acc n l =
+      match l with
+      | x :: xs ->
+          if n > 0 then (aux [@tailcall]) (x :: acc) (n - 1) xs else acc
+      | [] -> acc
+    in
+    aux [] n l
 
   let filter_map f l =
     let rec inner acc = function

--- a/src/alcotest-engine/utils.mli
+++ b/src/alcotest-engine/utils.mli
@@ -1,5 +1,9 @@
 val ( >> ) : ('a -> 'b) -> ('b -> 'c) -> 'a -> 'c
 
+module Fun : sig
+  val id : 'a -> 'a
+end
+
 module String : sig
   include module type of Astring.String
 
@@ -15,6 +19,9 @@ module List : sig
   include module type of List
 
   type 'a t = 'a list
+
+  val rev_head : int -> 'a list -> 'a list
+  (** Reverse a list, taking at most the first n elements of the original list. *)
 
   val filter_map : ('a -> 'b option) -> 'a list -> 'b list
   val lift_result : ('a, 'b) result t -> ('a t, 'b t) result

--- a/src/alcotest-mirage/alcotest_mirage.ml
+++ b/src/alcotest-mirage/alcotest_mirage.ml
@@ -2,11 +2,18 @@ module Make (C : Mirage_clock.MCLOCK) = struct
   module Platform (M : Alcotest_engine.Monad.S) = struct
     let time () = Duration.to_f @@ C.elapsed_ns ()
     let getcwd () = ""
-    let prepare ~base:_ ~dir:_ ~name:_ = ()
     let stdout_isatty () = true
     let stdout_columns () = None
-    let with_redirect _ fn = fn ()
     let setup_std_outputs ?style_renderer:_ ?utf_8:_ () = ()
+
+    type file_descriptor = |
+
+    let log_trap_supported = false
+    let prepare_log_trap ~root:_ = assert false
+    let file_exists _ = assert false
+    let open_write_only _ = assert false
+    let close = function (_ : file_descriptor) -> .
+    let with_redirect = function (_ : file_descriptor) -> .
 
     let home_directory () =
       Error (`Msg "Home directory not available for the MirageOS platform")

--- a/src/alcotest-mirage/alcotest_mirage.ml
+++ b/src/alcotest-mirage/alcotest_mirage.ml
@@ -6,14 +6,15 @@ module Make (C : Mirage_clock.MCLOCK) = struct
     let stdout_columns () = None
     let setup_std_outputs ?style_renderer:_ ?utf_8:_ () = ()
 
-    type file_descriptor = |
+    (* Pre-4.07 doesn't support empty variant types. *)
+    type file_descriptor = { empty : 'a. 'a }
 
     let log_trap_supported = false
     let prepare_log_trap ~root:_ = assert false
     let file_exists _ = assert false
     let open_write_only _ = assert false
-    let close = function (_ : file_descriptor) -> .
-    let with_redirect = function (_ : file_descriptor) -> .
+    let close = function (fd : file_descriptor) -> fd.empty
+    let with_redirect = function (fd : file_descriptor) -> fd.empty
 
     let home_directory () =
       Error (`Msg "Home directory not available for the MirageOS platform")

--- a/src/alcotest/alcotest.ml
+++ b/src/alcotest/alcotest.ml
@@ -29,7 +29,7 @@ module Unix (M : Alcotest_engine.Monad.S) = struct
       | xs -> mk "." xs
   end
 
-  open M.Infix
+  open M.Syntax
 
   let time = Unix.gettimeofday
   let getcwd = Sys.getcwd
@@ -90,7 +90,7 @@ module Unix (M : Alcotest_engine.Monad.S) = struct
   let close = Unix.close
 
   let with_redirect fd_file fn =
-    M.return () >>= fun () ->
+    let* () = M.return () in
     Fmt.(flush stdout) ();
     Fmt.(flush stderr) ();
     let fd_stdout = Unix.descr_of_out_channel stdout in
@@ -99,7 +99,7 @@ module Unix (M : Alcotest_engine.Monad.S) = struct
     let fd_old_stderr = Unix.dup fd_stderr in
     Unix.dup2 fd_file fd_stdout;
     Unix.dup2 fd_file fd_stderr;
-    (try fn () >|= fun o -> `Ok o with e -> M.return @@ `Error e) >|= fun r ->
+    let+ r = try fn () >|= fun o -> `Ok o with e -> M.return @@ `Error e in
     Fmt.(flush stdout ());
     Fmt.(flush stderr ());
     Unix.dup2 fd_old_stdout fd_stdout;

--- a/src/alcotest/alcotest.ml
+++ b/src/alcotest/alcotest.ml
@@ -59,12 +59,13 @@ module Unix (M : Alcotest_engine.Monad.S) = struct
     in
     inner ~retries:0
 
-  let prepare ~base ~dir ~name =
+  let prepare_log_trap ~root ~uuid ~name =
+    let dir = Filename.concat root uuid in
     if not (Sys.file_exists dir) then (
       Unix.mkdir_p dir 0o770;
       if Sys.unix || Sys.cygwin then (
-        let this_exe = Filename.concat base name
-        and latest = Filename.concat base "latest" in
+        let this_exe = Filename.concat root name
+        and latest = Filename.concat root "latest" in
         unlink_if_exists this_exe;
         unlink_if_exists latest;
         symlink ~to_dir:true ~target:dir ~link_name:this_exe;
@@ -81,7 +82,14 @@ module Unix (M : Alcotest_engine.Monad.S) = struct
       | Some { columns; _ } -> Some columns
       | None -> None
 
-  let with_redirect file fn =
+  type file_descriptor = Unix.file_descr
+
+  let log_trap_supported = true
+  let file_exists = Sys.file_exists
+  let open_write_only x = Unix.(openfile x [ O_WRONLY; O_TRUNC; O_CREAT ] 0o660)
+  let close = Unix.close
+
+  let with_redirect fd_file fn =
     M.return () >>= fun () ->
     Fmt.(flush stdout) ();
     Fmt.(flush stderr) ();
@@ -89,10 +97,8 @@ module Unix (M : Alcotest_engine.Monad.S) = struct
     let fd_stderr = Unix.descr_of_out_channel stderr in
     let fd_old_stdout = Unix.dup fd_stdout in
     let fd_old_stderr = Unix.dup fd_stderr in
-    let fd_file = Unix.(openfile file [ O_WRONLY; O_TRUNC; O_CREAT ] 0o660) in
     Unix.dup2 fd_file fd_stdout;
     Unix.dup2 fd_file fd_stderr;
-    Unix.close fd_file;
     (try fn () >|= fun o -> `Ok o with e -> M.return @@ `Error e) >|= fun r ->
     Fmt.(flush stdout ());
     Fmt.(flush stderr ());

--- a/src/alcotest/dune
+++ b/src/alcotest/dune
@@ -3,4 +3,5 @@
  (libraries alcotest.engine astring fmt fmt.tty)
  (foreign_stubs
   (language c)
-  (names alcotest_stubs)))
+  (names alcotest_stubs))
+ (preprocess future_syntax))


### PR DESCRIPTION
Pulls out a `Log_trap` component for capturing test logs in files.

This is another chunk of refactoring extracted from https://github.com/mirage/alcotest/pull/294, which requires some more complicated redirection logic.