### PR TITLE
Use shorter random IDs for test runs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+- Generate shorter unique identifiers for test runs (8-character alphanumeric,
+  rather than a full 128-bit UUID). (#304, @CraigFe)
+
 ### 1.4.0 (2021-04-15)
 
 - Add `?here` and `?pos` arguments to the test assertion functions. These can be

--- a/alcotest.opam
+++ b/alcotest.opam
@@ -24,7 +24,6 @@ depends: [
   "fmt" {>= "0.8.7"}
   "astring"
   "cmdliner" {>= "1.0.0"}
-  "uuidm"
   "re"
   "stdlib-shims"
   "uutf"

--- a/dune-project
+++ b/dune-project
@@ -28,7 +28,6 @@ tests to run.
   (fmt (>= 0.8.7))
   astring
   (cmdliner (>= 1.0.0))
-  uuidm
   re
   stdlib-shims
   uutf

--- a/src/alcotest-engine/core.ml
+++ b/src/alcotest-engine/core.ml
@@ -84,6 +84,16 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
     log_trap : Log_trap.t;
   }
 
+  let gen_run_id =
+    let random_state = lazy (Random.State.make_self_init ()) in
+    let random_hex _ =
+      let state = Lazy.force random_state in
+      match Random.State.int state 36 with
+      | n when n < 10 -> Char.chr (n + Char.code '0')
+      | n -> Char.chr (n - 10 + Char.code 'A')
+    in
+    fun () -> String.v ~len:8 random_hex
+
   let empty ~config ~trap_logs ~suite_name:unescaped_name =
     let errors = [] in
     let suite =
@@ -95,10 +105,7 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
              to `run`."
     in
     let max_label = 0 in
-    let run_id =
-      let random_state = Random.State.make_self_init () in
-      Uuidm.v4_gen random_state () |> Uuidm.to_string ~upper:true
-    in
+    let run_id = gen_run_id () in
     let log_trap =
       match trap_logs with
       | false -> Log_trap.inactive

--- a/src/alcotest-engine/dune
+++ b/src/alcotest-engine/dune
@@ -7,7 +7,6 @@
   astring
   cmdliner
   fmt.cli
-  uuidm
   re
   stdlib-shims
   uutf)

--- a/src/alcotest-engine/log_trap_intf.ml
+++ b/src/alcotest-engine/log_trap_intf.ml
@@ -8,8 +8,8 @@ open Model
 
     {[
       <log_capture_root_dir>
-      ├── E0965BF9-.../...
-      ├── 6DDB68D5-.../             ;; UUID for each test run
+      ├── E0965BF9/...
+      ├── 6DDB68D5/                 ;; ID for each test run
       │   │
       │   ├── alpha.000.output      ;; ... containing files for individual tests
       │   ├── alpha.001.output      ;;     with format <test_name>.<index>.output.

--- a/test/e2e/strip_randomness.ml
+++ b/test/e2e/strip_randomness.ml
@@ -38,14 +38,11 @@ let build_context_replace =
 
 let uuid_replace =
   let open Re in
-  let hex n = repn (alt [ rg 'A' 'F'; digit ]) n (Some n) in
-  let segmented_hex ns =
-    let segments = List.map (fun n -> [ char '-'; hex n ]) ns in
-    List.flatten segments |> List.tl |> seq
+  let t =
+    seq [ str "ID `"; repn (alt [ rg 'A' 'Z'; digit ]) 8 (Some 8); char '\'' ]
   in
-  let t = segmented_hex [ 8; 4; 4; 4; 12 ] in
   let re = compile t in
-  replace_string ~all:true re ~by:"<uuid>"
+  replace_string ~all:true re ~by:"ID `<uuid>'"
 
 let time_replace =
   let open Re in


### PR DESCRIPTION
Currently we use `uuidm` for generating test IDs. These seem a bit unnecessarily long to display / view when debugging: 8 alphanumeric characters is already enough for 3 trillion unique IDs, so I've gone with that.