### PR TITLE
Change the `~filter` test selector to be a predicate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 - Generate shorter unique identifiers for test runs (8-character alphanumeric,
   rather than a full 128-bit UUID). (#304, @CraigFe)
 
+- Change the `~filter` argument to `Alcotest.run` to be a predicate over tests.
+  (#305, @CraigFe)
+
 ### 1.4.0 (2021-04-15)
 
 - Add `?here` and `?pos` arguments to the test assertion functions. These can be

--- a/src/alcotest-engine/cli.ml
+++ b/src/alcotest-engine/cli.ml
@@ -18,12 +18,6 @@
 open! Import
 open Cmdliner
 
-module IntSet = Set.Make (struct
-  type t = int
-
-  let compare = (compare : int -> int -> int)
-end)
-
 module type S = sig
   include Core.S
 

--- a/src/alcotest-engine/config_intf.ml
+++ b/src/alcotest-engine/config_intf.ml
@@ -1,5 +1,6 @@
 module Types = struct
   type bound = [ `Unlimited | `Limit of int ]
+  type filter = name:string -> index:int -> [ `Run | `Skip ]
 
   type t =
     < and_exit : bool
@@ -9,7 +10,7 @@ module Types = struct
     ; quick_only : bool
     ; show_errors : bool
     ; json : bool
-    ; filter : Re.re option * int list option
+    ; filter : filter option
     ; log_dir : string
     ; bail : bool >
 
@@ -21,7 +22,7 @@ module Types = struct
     ?quick_only:bool ->
     ?show_errors:bool ->
     ?json:bool ->
-    ?filter:Re.re option * int list option ->
+    ?filter:filter ->
     ?log_dir:string ->
     ?bail:bool ->
     'a

--- a/src/alcotest-engine/core_intf.ml
+++ b/src/alcotest-engine/core_intf.ml
@@ -55,7 +55,7 @@ module type S = sig
     ?quick_only:bool ->
     ?show_errors:bool ->
     ?json:bool ->
-    ?filter:Re.re option * int list option ->
+    ?filter:(name:string -> index:int -> [ `Run | `Skip ]) ->
     ?log_dir:string ->
     ?bail:bool ->
     'a

--- a/src/alcotest-stdlib-ext/alcotest_stdlib_ext.ml
+++ b/src/alcotest-stdlib-ext/alcotest_stdlib_ext.ml
@@ -4,6 +4,14 @@ module Fun = struct
   let id x = x
 end
 
+module Int = struct
+  module Set = Set.Make (struct
+    type t = int
+
+    let compare = (compare : int -> int -> int)
+  end)
+end
+
 module String = struct
   include Astring.String
 
@@ -68,6 +76,7 @@ end
 
 module Option = struct
   let is_some = function Some _ -> true | None -> false
+  let map f = function Some x -> Some (f x) | None -> None
 
   let get_exn = function
     | Some x -> x

--- a/src/alcotest-stdlib-ext/alcotest_stdlib_ext.mli
+++ b/src/alcotest-stdlib-ext/alcotest_stdlib_ext.mli
@@ -4,6 +4,10 @@ module Fun : sig
   val id : 'a -> 'a
 end
 
+module Int : sig
+  module Set : Set.S with type elt = int
+end
+
 module String : sig
   include module type of Astring.String
 
@@ -33,6 +37,7 @@ module Result : sig
 end
 
 module Option : sig
+  val map : ('a -> 'b) -> 'a option -> 'b option
   val is_some : _ option -> bool
   val get_exn : 'a option -> 'a
   val value : default:'a -> 'a option -> 'a


### PR DESCRIPTION
The existing type of this argument is very obscure – and was added purely to
keep the CLI in correspondence with the runtime config – and so it's seen no
use in the Opam repository. This changes the type to be more sensible, in a way
that simplifies the V2 PR.