### PR TITLE
Extract a safe-string abstraction

### DIFF
--- a/src/alcotest-engine/core.ml
+++ b/src/alcotest-engine/core.ml
@@ -277,7 +277,7 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
     | Some p -> (
         let name, index =
           let tn = test_case.Suite.name in
-          Test_name.(name tn, index tn)
+          Test_name.(Safe_string.to_unescaped_string (name tn), index tn)
         in
         match p ~name ~index with `Run -> true | `Skip -> false)
 

--- a/src/alcotest-engine/safe_string.ml
+++ b/src/alcotest-engine/safe_string.ml
@@ -1,0 +1,32 @@
+open! Import
+
+let escape str =
+  let add_codepoint buf uchar =
+    Uchar.to_int uchar |> Fmt.str "U+%04X" |> Buffer.add_string buf
+  in
+  let buf = Buffer.create (String.length str * 2) in
+  let get_normalized_char _ _ u =
+    match u with
+    | `Uchar u ->
+        if Uchar.is_char u then
+          match Uchar.to_char u with
+          | ('A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '-' | ' ' | '.') as c
+            ->
+              Buffer.add_char buf c
+          | '/' | '\\' -> Buffer.add_char buf '-'
+          | _ -> add_codepoint buf u
+        else add_codepoint buf u
+    | `Malformed _ -> Uutf.Buffer.add_utf_8 buf Uutf.u_rep
+  in
+  Uutf.String.fold_utf_8 get_normalized_char () str;
+  Buffer.contents buf
+
+type t = { raw : string; escaped : string }
+
+let v raw = { raw; escaped = escape raw }
+let to_string { escaped; _ } = escaped
+let to_unescaped_string { raw; _ } = raw
+let pp = Fmt.using (fun { raw; _ } -> raw) Fmt.string
+let length { raw; _ } = String.length_utf8 raw
+let equal t t' = String.equal t.escaped t'.escaped
+let compare t t' = String.compare t.escaped t'.escaped

--- a/src/alcotest-engine/safe_string.mli
+++ b/src/alcotest-engine/safe_string.mli
@@ -1,0 +1,20 @@
+type t
+(** A UTF-8 encoded string that has been made safe for use in filesystems by
+    escaping any "unsafe" characters as their [U+XXXX] notational form. *)
+
+val v : string -> t
+
+val to_string : t -> string
+(** Get the escaped form of the given {!Safe_string}. *)
+
+val to_unescaped_string : t -> string
+(** Get the raw, unescaped string initially passed to [v]. *)
+
+val pp : t Fmt.t
+(** Pretty-print the unescaped string. *)
+
+val length : t -> int
+(** The approximate number of terminal columns consumed by [pp_name]. *)
+
+val equal : t -> t -> bool
+val compare : t -> t -> int


### PR DESCRIPTION
We have a few locations where it's necessary to track both a raw string and its UTF8-escaped equivalent (for use with file-system interactions).  This commit pulls out an abstraction for that pattern.

More changes from https://github.com/mirage/alcotest/pull/294.