### PR TITLE
Provide versioned aliases for the Async and Lwt backends

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,14 +7,16 @@
   (#305, @CraigFe)
 
 - Introduce an `Alcotest.V1` module that aliases the existing `Alcotest` API and
-  provides a stability guarantee over major version changes. (#306, @CraigFe)
+  provides a stability guarantee over major version changes. Similar versioned
+  aliases also exist for the backends: `Alcotest_{async,lwt}.V1`. (#306,
+  @CraigFe)
 
 - Renamed / removed some less frequently used modules used by the test backends:
   - `Alcotest.Unix` -> `Alcotest.Unix_platform`
   - `Alcotest_engine.{Cli,Core,Test}` -> `Alcotest_engine.V1.{Cli,Core,Test}`
   - `Alcotest.{Cli,Core}` are now gone. Use `Alcotest_engine.V1.{Cli,Core}.Make
     (Alcotest.Unix_platform)` instead.
-  (#306, @CraigFe)
+  (#306 #309, @CraigFe)
 
 - Avoid exporting `list_tests` in the main test APIs (`Alcotest{,_lwt,_async}`).
   Use `Alcotest_engine` directly if you want this function. (#310, @CraigFe)

--- a/src/alcotest-async/alcotest_async.ml
+++ b/src/alcotest-async/alcotest_async.ml
@@ -2,22 +2,6 @@ open Core
 open Async_kernel
 open Async_unix
 
-module Tester =
-  Alcotest_engine.V1.Cli.Make
-    (Alcotest.Unix_platform)
-    (struct
-      include Deferred
-
-      let bind x f = bind x ~f
-
-      let catch t on_error =
-        try_with t >>= function Ok a -> return a | Error exn -> on_error exn
-    end)
-
-include Tester
-
-let test_case_sync n s f = test_case n s (fun x -> Deferred.return (f x))
-
 let run_test timeout name fn args =
   Clock.with_timeout timeout (fn args) >>| function
   | `Result x -> x
@@ -26,5 +10,23 @@ let run_test timeout name fn args =
         (Printf.sprintf "%s timed out after %s" name
            (Time.Span.to_string_hum timeout))
 
-let test_case ?(timeout = sec 2.) name s f =
-  test_case name s (run_test timeout name f)
+module Promise = struct
+  include Deferred
+
+  let bind x f = bind x ~f
+
+  let catch t on_error =
+    try_with t >>= function Ok a -> return a | Error exn -> on_error exn
+end
+
+module V1 = struct
+  module Tester = Alcotest_engine.V1.Cli.Make (Alcotest.Unix_platform) (Promise)
+  include Tester
+
+  let test_case_sync n s f = test_case n s (fun x -> Deferred.return (f x))
+
+  let test_case ?(timeout = sec 2.) name s f =
+    test_case name s (run_test timeout name f)
+end
+
+include V1

--- a/src/alcotest-async/alcotest_async.mli
+++ b/src/alcotest-async/alcotest_async.mli
@@ -17,14 +17,4 @@
 (** [Alcotest_async] enables testing functions which return an Async deferred.
     {!run} returns a deferred which will run the tests when scheduled. *)
 
-include Alcotest_engine.V1.Cli.S with type return = unit Async_kernel.Deferred.t
-
-val test_case :
-  ?timeout:Core_kernel.Time.Span.t ->
-  string ->
-  Alcotest.speed_level ->
-  ('a -> unit Async_kernel.Deferred.t) ->
-  'a test_case
-
-val test_case_sync :
-  string -> Alcotest.speed_level -> ('a -> unit) -> 'a test_case
+include Alcotest_async_intf.Alcotest_async

--- a/src/alcotest-async/alcotest_async_intf.ml
+++ b/src/alcotest-async/alcotest_async_intf.ml
@@ -1,0 +1,24 @@
+module type V1 = sig
+  include
+    Alcotest_engine.V1.Cli.S with type return = unit Async_kernel.Deferred.t
+
+  val test_case :
+    ?timeout:Core_kernel.Time.Span.t ->
+    string ->
+    Alcotest.speed_level ->
+    ('a -> unit Async_kernel.Deferred.t) ->
+    'a test_case
+
+  val test_case_sync :
+    string -> Alcotest.speed_level -> ('a -> unit) -> 'a test_case
+end
+
+module type Alcotest_async = sig
+  include V1
+
+  (** {1 Versioned APIs} *)
+
+  module V1 : V1
+  (** An alias of the above API that provides a stability guarantees over major
+      version changes. *)
+end

--- a/src/alcotest-lwt/alcotest_lwt.ml
+++ b/src/alcotest-lwt/alcotest_lwt.ml
@@ -14,11 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Tester = Alcotest_engine.V1.Cli.Make (Alcotest.Unix_platform) (Lwt)
-include Tester
-
-let test_case_sync n s f = test_case n s (fun x -> Lwt.return (f x))
-
 let run_test fn args =
   let async_ex, async_waker = Lwt.wait () in
   let handle_exn ex =
@@ -28,4 +23,12 @@ let run_test fn args =
   Lwt.async_exception_hook := handle_exn;
   Lwt_switch.with_switch (fun sw -> Lwt.pick [ fn sw args; async_ex ])
 
-let test_case n s f = test_case n s (run_test f)
+module V1 = struct
+  module Tester = Alcotest_engine.V1.Cli.Make (Alcotest.Unix_platform) (Lwt)
+  include Tester
+
+  let test_case_sync n s f = test_case n s (fun x -> Lwt.return (f x))
+  let test_case n s f = test_case n s (run_test f)
+end
+
+include V1

--- a/src/alcotest-lwt/alcotest_lwt.mli
+++ b/src/alcotest-lwt/alcotest_lwt.mli
@@ -18,13 +18,4 @@
     returns a promise that runs the tests when scheduled, catching any
     asynchronous exceptions thrown by the tests. *)
 
-include Alcotest_engine.V1.Cli.S with type return = unit Lwt.t
-
-val test_case :
-  string ->
-  Alcotest.speed_level ->
-  (Lwt_switch.t -> 'a -> unit Lwt.t) ->
-  'a test_case
-
-val test_case_sync :
-  string -> Alcotest.speed_level -> ('a -> unit) -> 'a test_case
+include Alcotest_lwt_intf.Alcotest_lwt

--- a/src/alcotest-lwt/alcotest_lwt_intf.ml
+++ b/src/alcotest-lwt/alcotest_lwt_intf.ml
@@ -1,0 +1,22 @@
+module type V1 = sig
+  include Alcotest_engine.V1.Cli.S with type return = unit Lwt.t
+
+  val test_case :
+    string ->
+    Alcotest.speed_level ->
+    (Lwt_switch.t -> 'a -> unit Lwt.t) ->
+    'a test_case
+
+  val test_case_sync :
+    string -> Alcotest.speed_level -> ('a -> unit) -> 'a test_case
+end
+
+module type Alcotest_lwt = sig
+  include V1
+
+  (** {1 Versioned APIs} *)
+
+  module V1 : V1
+  (** An alias of the above API that provides a stability guarantees over major
+      version changes. *)
+end


### PR DESCRIPTION
Follow up to https://github.com/mirage/alcotest/pull/306.