### PR TITLE
Avoid exporting `list_tests` in the main test APIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
     (Alcotest.Unix_platform)` instead.
   (#306, @CraigFe)
 
+- Avoid exporting `list_tests` in the main test APIs (`Alcotest{,_lwt,_async}`).
+  Use `Alcotest_engine` directly if you want this function. (#310, @CraigFe)
+
 ### 1.4.0 (2021-04-15)
 
 - Add `?here` and `?pos` arguments to the test assertion functions. These can be

--- a/src/alcotest-engine/core_intf.ml
+++ b/src/alcotest-engine/core_intf.ml
@@ -45,9 +45,6 @@ module V1_types = struct
     (** A test is a UTF-8 encoded name and a list of test cases. The name can be
         used for filtering which tests to run on the CLI. *)
 
-    val list_tests : 'a test list -> return
-    (** Print all of the test cases in a human-readable form *)
-
     type 'a with_options =
       ?and_exit:bool ->
       ?verbose:bool ->
@@ -87,8 +84,14 @@ module V1_types = struct
   module type MAKER = functor (P : Platform.MAKER) (M : Monad.S) -> sig
     include S with type return = unit M.t
 
+    val list_tests : 'a test list -> return
+    (** Print all of the test cases in a human-readable form *)
+
     val run' : Config.User.t -> string -> unit test list -> return
+    (** Variant of {!run} that consumes a config value. *)
+
     val run_with_args' : Config.User.t -> string -> 'a -> 'a test list -> return
+    (** Variant of {!run_with_args} that consumes a config value. *)
   end
 end
 


### PR DESCRIPTION
This function is leaked mostly as an implementation detail (it's needed to support the `test` subcommand), but since test listing is accessible via a binary generated by `Alcotest.run`, this is an unintuitive distinction (and one that noone is actually relying on in the Opam repository).