### PR TITLE
Make alcotest work with js_of_ocaml

### DIFF
--- a/examples/bad/dune
+++ b/examples/bad/dune
@@ -1,5 +1,6 @@
 (executable
  (name bad)
+ (modes native js)
  (libraries alcotest astring))
 
 ; This fails at runtime, so just build the executable
@@ -8,3 +9,8 @@
  (name runtest)
  (package alcotest)
  (deps bad.exe))
+
+(alias
+ (name runtest-js)
+ (package alcotest)
+ (deps bad.bc.js))

--- a/examples/dune
+++ b/examples/dune
@@ -1,4 +1,15 @@
 (tests
  (names simple floats)
  (package alcotest)
+ (modes native js)
  (libraries alcotest))
+
+(rule
+ (alias runtest-js)
+ (action
+  (run node %{dep:floats.bc.js})))
+
+(rule
+ (alias runtest-js)
+ (action
+  (run node %{dep:simple.bc.js})))

--- a/src/alcotest-lwt/dune
+++ b/src/alcotest-lwt/dune
@@ -1,4 +1,4 @@
 (library
  (name alcotest_lwt)
  (public_name alcotest-lwt)
- (libraries logs lwt lwt.unix fmt alcotest.engine alcotest))
+ (libraries logs lwt fmt alcotest.engine alcotest))

--- a/src/alcotest/alcotest.ml
+++ b/src/alcotest/alcotest.ml
@@ -61,7 +61,7 @@ module Unix_platform (M : Alcotest_engine.Monad.S) = struct
     let dir = Filename.concat root uuid in
     if not (Sys.file_exists dir) then (
       Unix.mkdir_p dir 0o770;
-      if Sys.unix || Sys.cygwin then (
+      if (Sys.unix || Sys.cygwin) && Unix.has_symlink () then (
         let this_exe = Filename.concat root name
         and latest = Filename.concat root "latest" in
         unlink_if_exists this_exe;

--- a/src/alcotest/alcotest.ml
+++ b/src/alcotest/alcotest.ml
@@ -91,7 +91,7 @@ module Unix_platform (M : Alcotest_engine.Monad.S) = struct
 
   let log_trap_supported = true
   let file_exists = Sys.file_exists
-  let open_write_only x = open_out x
+  let open_write_only = open_out
   let close = close_out
 
   let with_redirect fd_file fn =

--- a/src/alcotest/alcotest_stubs.c
+++ b/src/alcotest/alcotest_stubs.c
@@ -80,3 +80,80 @@ CAMLprim value ocaml_alcotest_get_terminal_dimensions(value unit)
 }
 
 #endif
+
+
+/* The definition of channel should be kept in sync with upstream ocaml  */
+/* Start of duplicated code from caml/io.h */
+#ifndef IO_BUFFER_SIZE
+#define IO_BUFFER_SIZE 65536
+#endif
+
+#if defined(_WIN32)
+typedef __int64 file_offset;
+#elif defined(HAS_OFF_T)
+#include <sys/types.h>
+typedef off_t file_offset;
+#else
+typedef long file_offset;
+#endif
+
+struct channel {
+  int fd;                       /* Unix file descriptor */
+  file_offset offset;           /* Absolute position of fd in the file */
+  char * end;                   /* Physical end of the buffer */
+  char * curr;                  /* Current position in the buffer */
+  char * max;                   /* Logical end of the buffer (for input) */
+  void * mutex;                 /* Placeholder for mutex (for systhreads) */
+  struct channel * next, * prev;/* Double chaining of channels (flush_all) */
+  int revealed;                 /* For Cash only */
+  int old_revealed;             /* For Cash only */
+  int refcount;                 /* For flush_all and for Cash */
+  int flags;                    /* Bitfield */
+  char buff[IO_BUFFER_SIZE];    /* The buffer itself */
+  char * name;                  /* Optional name (to report fd leaks) */
+};
+
+#define Channel(v) (*((struct channel **) (Data_custom_val(v))))
+
+/* End of duplicated code from caml/io.h */
+
+/* Start of duplicated code from caml/sys.h */
+#define NO_ARG Val_int(0)
+CAMLextern void caml_sys_error (value);
+/* End of duplicated code from caml/sys.h */
+
+static int alcotest_saved_stdout;
+static int alcotest_saved_stderr;
+
+CAMLprim value alcotest_before_test (value voutput, value vstdout, value vstderr) {
+  struct channel* output = Channel(voutput);
+  struct channel* cstdout = Channel(vstdout);
+  struct channel* cstderr = Channel(vstderr);
+  int fd, ret;
+  fd = dup(cstdout->fd);
+  if(fd == -1) caml_sys_error(NO_ARG);
+  alcotest_saved_stdout = fd;
+  fd = dup(cstderr->fd);
+  if(fd == -1) caml_sys_error(NO_ARG);
+  alcotest_saved_stderr = fd;
+  ret = dup2(output->fd, cstdout->fd);
+  if(ret == -1) caml_sys_error(NO_ARG);
+  ret = dup2(output->fd, cstderr->fd);
+  if(ret == -1) caml_sys_error(NO_ARG);
+  return Val_unit;
+}
+
+CAMLprim value alcotest_after_test (value vstdout, value vstderr) {
+  struct channel* cstdout = Channel(vstdout);
+  struct channel* cstderr = Channel(vstderr);
+  int ret;
+  ret = dup2(alcotest_saved_stdout, cstdout->fd);
+  if(ret == -1) caml_sys_error(NO_ARG);
+  ret = dup2(alcotest_saved_stderr, cstderr->fd);
+  if(ret == -1) caml_sys_error(NO_ARG);
+  ret = close(alcotest_saved_stdout);
+  if(ret == -1) caml_sys_error(NO_ARG);
+  ret = close(alcotest_saved_stderr);
+  if(ret == -1) caml_sys_error(NO_ARG);
+  return Val_unit;
+}

--- a/src/alcotest/alcotest_stubs.c
+++ b/src/alcotest/alcotest_stubs.c
@@ -81,75 +81,40 @@ CAMLprim value ocaml_alcotest_get_terminal_dimensions(value unit)
 
 #endif
 
-
-/* The definition of channel should be kept in sync with upstream ocaml  */
-/* Start of duplicated code from caml/io.h */
-#ifndef IO_BUFFER_SIZE
-#define IO_BUFFER_SIZE 65536
-#endif
-
-#if defined(_WIN32)
-typedef __int64 file_offset;
-#elif defined(HAS_OFF_T)
-#include <sys/types.h>
-typedef off_t file_offset;
-#else
-typedef long file_offset;
-#endif
-
-struct channel {
-  int fd;                       /* Unix file descriptor */
-  file_offset offset;           /* Absolute position of fd in the file */
-  char * end;                   /* Physical end of the buffer */
-  char * curr;                  /* Current position in the buffer */
-  char * max;                   /* Logical end of the buffer (for input) */
-  void * mutex;                 /* Placeholder for mutex (for systhreads) */
-  struct channel * next, * prev;/* Double chaining of channels (flush_all) */
-  int revealed;                 /* For Cash only */
-  int old_revealed;             /* For Cash only */
-  int refcount;                 /* For flush_all and for Cash */
-  int flags;                    /* Bitfield */
-  char buff[IO_BUFFER_SIZE];    /* The buffer itself */
-  char * name;                  /* Optional name (to report fd leaks) */
-};
-
-#define Channel(v) (*((struct channel **) (Data_custom_val(v))))
-
-/* End of duplicated code from caml/io.h */
-
-/* Start of duplicated code from caml/sys.h */
+/* duplicated from caml/sys.h and io.c */
+CAMLextern value caml_channel_descriptor(value vchannel);
 #define NO_ARG Val_int(0)
 CAMLextern void caml_sys_error (value);
-/* End of duplicated code from caml/sys.h */
+/* End of code duplicatio */
 
 static int alcotest_saved_stdout;
 static int alcotest_saved_stderr;
 
 CAMLprim value alcotest_before_test (value voutput, value vstdout, value vstderr) {
-  struct channel* output = Channel(voutput);
-  struct channel* cstdout = Channel(vstdout);
-  struct channel* cstderr = Channel(vstderr);
-  int fd, ret;
-  fd = dup(cstdout->fd);
+  int output_fd, stdout_fd, stderr_fd, fd, ret;
+  stdout_fd = Int_val(caml_channel_descriptor(vstdout));
+  stderr_fd = Int_val(caml_channel_descriptor(vstderr));
+  output_fd = Int_val(caml_channel_descriptor(voutput));
+  fd = dup(stdout_fd);
   if(fd == -1) caml_sys_error(NO_ARG);
   alcotest_saved_stdout = fd;
-  fd = dup(cstderr->fd);
+  fd = dup(stderr_fd);
   if(fd == -1) caml_sys_error(NO_ARG);
   alcotest_saved_stderr = fd;
-  ret = dup2(output->fd, cstdout->fd);
+  ret = dup2(output_fd, stdout_fd);
   if(ret == -1) caml_sys_error(NO_ARG);
-  ret = dup2(output->fd, cstderr->fd);
+  ret = dup2(output_fd, stderr_fd);
   if(ret == -1) caml_sys_error(NO_ARG);
   return Val_unit;
 }
 
 CAMLprim value alcotest_after_test (value vstdout, value vstderr) {
-  struct channel* cstdout = Channel(vstdout);
-  struct channel* cstderr = Channel(vstderr);
-  int ret;
-  ret = dup2(alcotest_saved_stdout, cstdout->fd);
+  int stdout_fd, stderr_fd, ret;
+  stdout_fd = Int_val(caml_channel_descriptor(vstdout));
+  stderr_fd = Int_val(caml_channel_descriptor(vstderr));
+  ret = dup2(alcotest_saved_stdout, stdout_fd);
   if(ret == -1) caml_sys_error(NO_ARG);
-  ret = dup2(alcotest_saved_stderr, cstderr->fd);
+  ret = dup2(alcotest_saved_stderr, stderr_fd);
   if(ret == -1) caml_sys_error(NO_ARG);
   ret = close(alcotest_saved_stdout);
   if(ret == -1) caml_sys_error(NO_ARG);

--- a/src/alcotest/alcotest_stubs.c
+++ b/src/alcotest/alcotest_stubs.c
@@ -1,12 +1,12 @@
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
+#include <unistd.h>
 
 // Detect platform
 #if defined(_WIN32)
 #define OCAML_ALCOTEST_WINDOWS
 #elif defined(__unix__) || defined(__unix)
-#include <unistd.h>
 #if defined(_POSIX_VERSION)
 #define OCAML_ALCOTEST_POSIX
 #endif

--- a/src/alcotest/dune
+++ b/src/alcotest/dune
@@ -4,4 +4,6 @@
  (foreign_stubs
   (language c)
   (names alcotest_stubs))
+ (js_of_ocaml
+  (javascript_files runtime.js))
  (preprocess future_syntax))

--- a/src/alcotest/runtime.js
+++ b/src/alcotest/runtime.js
@@ -23,3 +23,13 @@ function alcotest_after_test (vstdout, vstderr){
   caml_ml_channels[vstderr] = alcotest_saved_stderr;
   return 0;
 }
+
+
+//Provides: ocaml_alcotest_get_terminal_dimensions
+function ocaml_alcotest_get_terminal_dimensions(unit) {
+  var p = joo_global_object.process
+  if(p && p.stdout && p.stdout.columns && p.stdout.rows) {
+    return [0, p.stdout.rows, p.stdout.columns];
+  }
+  return 0;
+}

--- a/src/alcotest/runtime.js
+++ b/src/alcotest/runtime.js
@@ -1,0 +1,25 @@
+//Provides: alcotest_saved_stdout
+var alcotest_saved_stdout 
+//Provides: alcotest_saved_stderr
+var alcotest_saved_stderr
+
+//Provides: alcotest_before_test
+//Requires: caml_global_data, caml_ml_channels
+//Requires: alcotest_saved_stderr, alcotest_saved_stdout
+function alcotest_before_test (voutput, vstdout, vstderr){
+  alcotest_saved_stderr = caml_ml_channels[vstderr];
+  alcotest_saved_stdout = caml_ml_channels[vstdout];
+  var output = caml_ml_channels[voutput];
+  caml_ml_channels[vstdout] = output;
+  caml_ml_channels[vstderr] = output;
+  return 0;
+}
+
+//Provides: alcotest_after_test
+//Requires: caml_global_data, caml_ml_channels
+//Requires: alcotest_saved_stderr, alcotest_saved_stdout
+function alcotest_after_test (vstdout, vstderr){
+  caml_ml_channels[vstdout] = alcotest_saved_stdout;
+  caml_ml_channels[vstderr] = alcotest_saved_stderr;
+  return 0;
+}

--- a/src/alcotest/runtime.js
+++ b/src/alcotest/runtime.js
@@ -24,7 +24,6 @@ function alcotest_after_test (vstdout, vstderr){
   return 0;
 }
 
-
 //Provides: ocaml_alcotest_get_terminal_dimensions
 function ocaml_alcotest_get_terminal_dimensions(unit) {
   var p = joo_global_object.process


### PR DESCRIPTION
- partially fix https://github.com/mirage/alcotest/issues/120
- could replace the node backend implemented in https://github.com/mirage/alcotest/pull/323

I've also created the same change against the latest version released 1.4.
See https://github.com/hhugo/alcotest/tree/alcotest.1.4+jsoo

This PR requires an unreleased version of js_of_ocaml-compiler https://github.com/ocsigen/js_of_ocaml/pull/1149