### PR TITLE
Avoid usage of deprecated Fmt functions

### DIFF
--- a/src/alcotest-engine/cli.ml
+++ b/src/alcotest-engine/cli.ml
@@ -44,7 +44,7 @@ module Make (P : Platform.MAKER) (M : Monad.S) :
       let color = Arg.enum enum in
       let enum_alts = Arg.doc_alts_enum enum in
       let doc =
-        Fmt.strf
+        Fmt.str
           "Colorize the output. $(docv) must be %s. Defaults to %s when \
            running inside Dune, otherwise defaults to %s."
           enum_alts (Arg.doc_quote "always") (Arg.doc_quote "auto")

--- a/src/alcotest-engine/core.ml
+++ b/src/alcotest-engine/core.ml
@@ -136,7 +136,7 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
 
   let color c ppf fmt = Fmt.(styled c string) ppf fmt
   let red_s fmt = color `Red fmt
-  let red ppf fmt = Fmt.kstrf (fun str -> red_s ppf str) fmt
+  let red ppf fmt = Fmt.kstr (fun str -> red_s ppf str) fmt
 
   let pp_error t ppf e =
     let path, error_fmt =

--- a/src/alcotest-engine/log_trap.ml
+++ b/src/alcotest-engine/log_trap.ml
@@ -57,7 +57,7 @@ struct
         let display_lines =
           if omitted_count = 0 then selected_lines
           else
-            Fmt.strf "... (omitting %i line%a)" omitted_count Pp.pp_plural
+            Fmt.str "... (omitting %i line%a)" omitted_count Pp.pp_plural
               omitted_count
             :: selected_lines
         in

--- a/src/alcotest-engine/pp.ml
+++ b/src/alcotest-engine/pp.ml
@@ -58,7 +58,7 @@ struct
   (* Colours *)
   let color c ppf fmt = Fmt.(styled c string) ppf fmt
   let red_s fmt = color `Red fmt
-  let red ppf fmt = Fmt.kstrf (fun str -> red_s ppf str) fmt
+  let red ppf fmt = Fmt.kstr (fun str -> red_s ppf str) fmt
   let green_s fmt = color `Green fmt
   let yellow_s fmt = color `Yellow fmt
   let left_gutter = 2

--- a/src/alcotest-engine/test.ml
+++ b/src/alcotest-engine/test.ml
@@ -62,7 +62,7 @@ let bytes =
   testable (fun fmt bytes -> Fmt.fmt "%S" fmt (Bytes.to_string bytes)) ( = )
 
 let bool = testable Fmt.bool ( = )
-let unit = testable (Fmt.unit "()") ( = )
+let unit = testable (Fmt.any "()") ( = )
 
 let list e =
   let rec eq l1 l2 =
@@ -207,7 +207,7 @@ let fail ?here ?pos msg =
   check_err (fun ppf () ->
       Fmt.pf ppf "%t%a %s" (pp_location ?here ?pos) Pp.tag `Fail msg)
 
-let failf ?here ?pos fmt = Fmt.kstrf (fun msg -> fail ?here ?pos msg) fmt
+let failf ?here ?pos fmt = Fmt.kstr (fun msg -> fail ?here ?pos msg) fmt
 let neg t = testable (pp t) (fun x y -> not (equal t x y))
 
 let collect_exception f =

--- a/src/alcotest/alcotest.ml
+++ b/src/alcotest/alcotest.ml
@@ -17,7 +17,7 @@ module Unix_platform (M : Alcotest_engine.Monad.S) = struct
             (try Unix.mkdir path mode
              with Unix.Unix_error (Unix.EEXIST, _, _) ->
                if Sys.is_directory path then () (* the directory exists *)
-               else Fmt.strf "mkdir: %s: is a file" path |> failwith);
+               else Fmt.str "mkdir: %s: is a file" path |> failwith);
             mk path names
       in
       match String.cuts ~empty:true ~sep path with


### PR DESCRIPTION
`Fmt.{strf,kstrf,unit}` were deprecated by the recently-released `fmt.0.8.10` in favour of equivalents with different names.