### PR TITLE
Fix compilation on bytecode architectures

### DIFF
--- a/examples/bad/dune
+++ b/examples/bad/dune
@@ -1,6 +1,6 @@
 (executable
  (name bad)
- (modes native js)
+ (modes exe js)
  (libraries alcotest astring))
 
 ; This fails at runtime, so just build the executable

--- a/examples/dune
+++ b/examples/dune
@@ -1,6 +1,6 @@
 (executables
  (names simple floats)
- (modes native js)
+ (modes exe js)
  (libraries alcotest))
 
 (rule

--- a/test/e2e/alcotest-lwt/failing/dune.inc
+++ b/test/e2e/alcotest-lwt/failing/dune.inc
@@ -4,7 +4,7 @@
    fail_with
  )
  (libraries alcotest alcotest.stdlib_ext alcotest-lwt lwt lwt.unix)
- (modes native)
+ (modes exe)
  (modules
    async_failure
    fail_with

--- a/test/e2e/alcotest-lwt/passing/dune.inc
+++ b/test/e2e/alcotest-lwt/passing/dune.inc
@@ -3,7 +3,7 @@
    cli_options
  )
  (libraries alcotest alcotest.stdlib_ext alcotest-lwt lwt lwt.unix)
- (modes native)
+ (modes exe)
  (modules
    cli_options
  )

--- a/test/e2e/alcotest/failing/dune.inc
+++ b/test/e2e/alcotest/failing/dune.inc
@@ -17,7 +17,7 @@
    unknown_option
  )
  (libraries alcotest alcotest.stdlib_ext alcotest.engine)
- (modes native js)
+ (modes exe js)
  (modules
    bail
    check_basic

--- a/test/e2e/alcotest/passing/dune.inc
+++ b/test/e2e/alcotest/passing/dune.inc
@@ -23,7 +23,7 @@
    verbose_newlines
  )
  (libraries alcotest alcotest.stdlib_ext alcotest.engine)
- (modes native js)
+ (modes exe js)
  (modules
    and_exit_false
    and_exit_true

--- a/test/e2e/gen_dune_rules.ml
+++ b/test/e2e/gen_dune_rules.ml
@@ -53,7 +53,7 @@ let global_stanza ~libraries ~js filenames =
     (pp_sexp_list Fmt.string) bases
     Fmt.(list string)
     libraries
-    (if js then "(modes native js)" else "(modes native)")
+    (if js then "(modes exe js)" else "(modes exe)")
     (pp_sexp_list Fmt.string) bases
 
 let example_rule_stanza ~js ~expect_failure filename =


### PR DESCRIPTION
Patch applied in Debian, so that alcotest's build and tests pass on all Debian architectures.