### PR TITLE
Preview: upgrade to ocamlformat.0.21.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.19.0
+version = 0.21.0
 profile = conventional
 
 module-item-spacing = compact

--- a/src/alcotest-engine/pp.ml
+++ b/src/alcotest-engine/pp.ml
@@ -197,8 +197,7 @@ struct
   let horizontal_rule (type a) ppf (_ : a) =
     let open Fmt in
     (const string " "
-    ++ const
-         (styled `Faint string)
+    ++ const (styled `Faint string)
          (List.init (Lazy.force terminal_width - 2) (fun _ -> "─")
          |> String.concat)
     ++ cut)


### PR DESCRIPTION
This is a preview of the formatting of your project codebase with the upcoming `ocamlformat.0.21.0`. Note that this package is not yet released in opam (so the linting/formatting task of your CI won't pass), the formatting might also change slightly in the released version as we try to integrate feedback from our users.

The changes on this project are due to:
- the list of arguments of function applications break on "complex" argument, an argument being composed of a variant is not considered being "complex" anymore.

As always, we are happy to hear your feedback!  Thank you for using ocamlformat!