### PR TITLE
Correctly lower-bound on OCaml 4.05

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,6 @@
-version = 0.19.0
+version = 0.20.1
 profile = conventional
+ocaml-version = 4.05.0
 
 module-item-spacing = compact
 break-infix = fit-or-vertical

--- a/alcotest-async.opam
+++ b/alcotest-async.opam
@@ -16,7 +16,7 @@ depends: [
   "core"
   "base"
   "async_kernel"
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.05.0"}
   "alcotest" {= version}
   "async_unix" {>= "v0.9.0"}
   "core_kernel" {>= "v0.9.0"}

--- a/alcotest-lwt.opam
+++ b/alcotest-lwt.opam
@@ -13,7 +13,7 @@ depends: [
   "re" {with-test}
   "cmdliner" {with-test & < "1.1.0"}
   "fmt"
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.05.0"}
   "alcotest" {= version}
   "lwt"
   "logs"

--- a/alcotest-mirage.opam
+++ b/alcotest-mirage.opam
@@ -13,7 +13,7 @@ depends: [
   "re" {with-test}
   "cmdliner" {with-test & < "1.1.0"}
   "fmt"
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.05.0"}
   "alcotest" {= version}
   "mirage-clock" {>= "2.0.0"}
   "duration"

--- a/alcotest.opam
+++ b/alcotest.opam
@@ -20,7 +20,7 @@ doc: "https://mirage.github.io/alcotest"
 bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.05.0"}
   "fmt" {>= "0.8.7"}
   "astring"
   "cmdliner" {>= "1.0.0" & < "1.1.0"}

--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,7 @@ inspect), with a simple (yet expressive) query language to select the
 tests to run.
 ")
  (depends
-  (ocaml (>= 4.03.0))
+  (ocaml (>= 4.05.0))
   (fmt (>= 0.8.7))
   astring
   (cmdliner (and (>= 1.0.0) (< 1.1.0)))
@@ -48,7 +48,7 @@ tests to run.
   core
   base
   async_kernel
-  (ocaml (>= 4.03.0))
+  (ocaml (>= 4.05.0))
   (alcotest (= :version))
   (async_unix (>= v0.9.0))
   (core_kernel (>= v0.9.0))))
@@ -62,7 +62,7 @@ tests to run.
   (re :with-test)
   (cmdliner (and :with-test (< 1.1.0)))
   fmt
-  (ocaml (>= 4.03.0))
+  (ocaml (>= 4.05.0))
   (alcotest (= :version))
   lwt
   logs))
@@ -76,7 +76,7 @@ tests to run.
   (re :with-test)
   (cmdliner (and :with-test (< 1.1.0)))
   fmt
-  (ocaml (>= 4.03.0))
+  (ocaml (>= 4.05.0))
   (alcotest (= :version))
   (mirage-clock (>= 2.0.0))
   duration


### PR DESCRIPTION
`alcotest >= 1.5.0 → fmt >= 0.8.7 → ocaml >= 4.05.0`
Also set OCamlFormat parser to OCaml 4.05 to make sure it doesn't reformat using newer syntax.