### PR TITLE
Constrain packages to avoid Cmdliner.1.1.0

### DIFF
--- a/alcotest-async.opam
+++ b/alcotest-async.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.8"}
   "re" {with-test}
   "fmt" {with-test}
-  "cmdliner" {with-test}
+  "cmdliner" {with-test & < "1.1.0"}
   "core"
   "base"
   "async_kernel"

--- a/alcotest-js.opam
+++ b/alcotest-js.opam
@@ -15,7 +15,7 @@ depends: [
   "alcotest" {= version}
   "js_of_ocaml-compiler" {>= "3.11.0"}
   "fmt" {with-test & >= "0.8.7"}
-  "cmdliner" {with-test & >= "1.0.0"}
+  "cmdliner" {with-test & >= "1.0.0" & < "1.1.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/alcotest-lwt.opam
+++ b/alcotest-lwt.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
   "dune" {>= "2.8"}
   "re" {with-test}
-  "cmdliner" {with-test}
+  "cmdliner" {with-test & < "1.1.0"}
   "fmt"
   "ocaml" {>= "4.03.0"}
   "alcotest" {= version}

--- a/alcotest-mirage.opam
+++ b/alcotest-mirage.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
   "dune" {>= "2.8"}
   "re" {with-test}
-  "cmdliner" {with-test}
+  "cmdliner" {with-test & < "1.1.0"}
   "fmt"
   "ocaml" {>= "4.03.0"}
   "alcotest" {= version}

--- a/alcotest.opam
+++ b/alcotest.opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "fmt" {>= "0.8.7"}
   "astring"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.0.0" & < "1.1.0"}
   "re" {>= "1.7.2"}
   "stdlib-shims"
   "uutf" {>= "1.0.1"}

--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@ tests to run.
   (ocaml (>= 4.03.0))
   (fmt (>= 0.8.7))
   astring
-  (cmdliner (>= 1.0.0))
+  (cmdliner (and (>= 1.0.0) (< 1.1.0)))
   (re (>= 1.7.2))
   stdlib-shims
   (uutf (>= 1.0.1))
@@ -44,7 +44,7 @@ tests to run.
  (depends
   (re :with-test)
   (fmt :with-test)
-  (cmdliner :with-test)
+  (cmdliner (and :with-test (< 1.1.0)))
   core
   base
   async_kernel
@@ -60,7 +60,7 @@ tests to run.
  (documentation "https://mirage.github.io/alcotest")
  (depends
   (re :with-test)
-  (cmdliner :with-test)
+  (cmdliner (and :with-test (< 1.1.0)))
   fmt
   (ocaml (>= 4.03.0))
   (alcotest (= :version))
@@ -74,7 +74,7 @@ tests to run.
  (documentation "https://mirage.github.io/alcotest")
  (depends
   (re :with-test)
-  (cmdliner :with-test)
+  (cmdliner (and :with-test (< 1.1.0)))
   fmt
   (ocaml (>= 4.03.0))
   (alcotest (= :version))
@@ -92,4 +92,4 @@ tests to run.
   (alcotest (= :version))
   (js_of_ocaml-compiler (>= 3.11.0))
   (fmt (and :with-test (>= 0.8.7)))
-  (cmdliner (and :with-test (>= 1.0.0)))))
+  (cmdliner (and :with-test (>= 1.0.0) (< 1.1.0)))))


### PR DESCRIPTION
This release is incompatible with Alcotest for now.

Temporarily solution to fix the CI until https://github.com/mirage/alcotest/pull/339 can be merged.