### PR TITLE
Rename the default branch to 'main'

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -2,7 +2,7 @@ name: Changelog check
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ The high-level project structure is as follows:
 ## Expect tests
 
 The repository contains a number of 'expect' tests in
-https://github.com/mirage/alcotest/tree/master/test/e2e. These are short,
+https://github.com/mirage/alcotest/tree/main/test/e2e. These are short,
 self-contained usages of the Alcotest API, with the corresponding output
 snapshotted in an `.expected` file:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ manpage](./alcotest-help.txt) for details.
 The API documentation can be found [here][docs]. For information on contributing to Alcotest, see
 [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-[![OCaml-CI Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Fmirage%2Falcotest%2Fmaster&logo=ocaml)](https://ci.ocamllabs.io/github/mirage/alcotest)
+[![OCaml-CI Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Fmirage%2Falcotest%2Fmain&logo=ocaml)](https://ci.ocamllabs.io/github/mirage/alcotest)
 [![docs](https://img.shields.io/badge/doc-online-blue.svg)](https://mirage.github.io/alcotest/alcotest/Alcotest/index.html)
 
 <hr/>
@@ -104,7 +104,7 @@ Test Successful in 0.000s. 1 test run.
 Note that you cannot filter by test case name (i.e. `Lower case` or `Capitalization`), you must
 filter by test name & number instead.
 
-See the [examples](https://github.com/mirage/alcotest/tree/master/examples)
+See the [examples](https://github.com/mirage/alcotest/tree/main/examples)
 folder for more examples.
 
 ### Quick and Slow tests


### PR DESCRIPTION
Already done in GitHub, but there are some bits in the repository itself to tweak.