### PR TITLE
Generalize the type of check_raises

### DIFF
--- a/src/alcotest-engine/test.ml
+++ b/src/alcotest-engine/test.ml
@@ -218,7 +218,7 @@ let neg t = testable (pp t) (fun x y -> not (equal t x y))
 
 let collect_exception f =
   try
-    f ();
+    ignore (f ());
     None
   with e -> Some e
 

--- a/src/alcotest-engine/test.mli
+++ b/src/alcotest-engine/test.mli
@@ -142,5 +142,5 @@ val fail : (string -> 'a) extra_info
 val failf : (('a, Format.formatter, unit, 'b) format4 -> 'a) extra_info
 (** Simply fail with a formatted message. *)
 
-val check_raises : (string -> exn -> (unit -> unit) -> unit) extra_info
+val check_raises : (string -> exn -> (unit -> 'a) -> unit) extra_info
 (** Check that an exception is raised. *)


### PR DESCRIPTION
Rationale: (1) the function we wish to test might not have `unit` as its codomain type, and (2) the dropping is not silent; if some value was returned and then dropped, the check would fail and the programmer would know.

Question: I did not touch `CHANGES.md` because I could not find a section for unreleased features. Maybe I missed something?