### PR TITLE
refactor: update to cmdliner 1.1.0

### DIFF
--- a/alcotest-async.opam
+++ b/alcotest-async.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.8"}
   "re" {with-test}
   "fmt" {with-test}
-  "cmdliner" {with-test & < "1.1.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
   "core"
   "base"
   "async_kernel"

--- a/alcotest-js.opam
+++ b/alcotest-js.opam
@@ -15,7 +15,7 @@ depends: [
   "alcotest" {= version}
   "js_of_ocaml-compiler" {>= "3.11.0"}
   "fmt" {with-test & >= "0.8.7"}
-  "cmdliner" {with-test & >= "1.0.0" & < "1.1.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/alcotest-lwt.opam
+++ b/alcotest-lwt.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
   "dune" {>= "2.8"}
   "re" {with-test}
-  "cmdliner" {with-test & < "1.1.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
   "fmt"
   "ocaml" {>= "4.05.0"}
   "alcotest" {= version}

--- a/alcotest-mirage.opam
+++ b/alcotest-mirage.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
   "dune" {>= "2.8"}
   "re" {with-test}
-  "cmdliner" {with-test & < "1.1.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
   "fmt"
   "ocaml" {>= "4.05.0"}
   "alcotest" {= version}

--- a/alcotest.opam
+++ b/alcotest.opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "fmt" {>= "0.8.7"}
   "astring"
-  "cmdliner" {>= "1.0.0" & < "1.1.0"}
+  "cmdliner" {>= "1.1.0"}
   "re" {>= "1.7.2"}
   "stdlib-shims"
   "uutf" {>= "1.0.1"}

--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@ tests to run.
   (ocaml (>= 4.05.0))
   (fmt (>= 0.8.7))
   astring
-  (cmdliner (and (>= 1.0.0) (< 1.1.0)))
+  (cmdliner (>= 1.1.0))
   (re (>= 1.7.2))
   stdlib-shims
   (uutf (>= 1.0.1))
@@ -44,7 +44,7 @@ tests to run.
  (depends
   (re :with-test)
   (fmt :with-test)
-  (cmdliner (and :with-test (< 1.1.0)))
+  (cmdliner (and :with-test (>= 1.1.0)))
   core
   base
   async_kernel
@@ -60,7 +60,7 @@ tests to run.
  (documentation "https://mirage.github.io/alcotest")
  (depends
   (re :with-test)
-  (cmdliner (and :with-test (< 1.1.0)))
+  (cmdliner (and :with-test (>= 1.1.0)))
   fmt
   (ocaml (>= 4.05.0))
   (alcotest (= :version))
@@ -74,7 +74,7 @@ tests to run.
  (documentation "https://mirage.github.io/alcotest")
  (depends
   (re :with-test)
-  (cmdliner (and :with-test (< 1.1.0)))
+  (cmdliner (and :with-test (>= 1.1.0)))
   fmt
   (ocaml (>= 4.05.0))
   (alcotest (= :version))
@@ -92,4 +92,4 @@ tests to run.
   (alcotest (= :version))
   (js_of_ocaml-compiler (>= 3.11.0))
   (fmt (and :with-test (>= 0.8.7)))
-  (cmdliner (and :with-test (>= 1.0.0) (< 1.1.0)))))
+  (cmdliner (and :with-test (>= 1.1.0)))))

--- a/src/alcotest-engine/config.ml
+++ b/src/alcotest-engine/config.ml
@@ -49,7 +49,7 @@ module Key = struct
 
   module Verbose = Flag (struct
     let term =
-      let env = Arg.env_var "ALCOTEST_VERBOSE" in
+      let env = Cmdliner.Cmd.Env.info "ALCOTEST_VERBOSE" in
       let doc =
         "Display the test outputs. $(b,WARNING:) when using this option the \
          output logs will not be available for further inspection."
@@ -59,14 +59,14 @@ module Key = struct
 
   module Compact = Flag (struct
     let term =
-      let env = Arg.env_var "ALCOTEST_COMPACT" in
+      let env = Cmdliner.Cmd.Env.info "ALCOTEST_COMPACT" in
       let doc = "Compact the output of the tests." in
       Arg.(value & flag & info ~env [ "c"; "compact" ] ~docv:"" ~doc)
   end)
 
   module Bail = Flag (struct
     let term =
-      let env = Arg.env_var "ALCOTEST_BAIL" in
+      let env = Cmdliner.Cmd.Env.info "ALCOTEST_BAIL" in
       let doc = "Stop running tests after the first failure." in
       Arg.(value & flag & info ~env [ "bail" ] ~docv:"" ~doc)
   end)
@@ -79,14 +79,14 @@ module Key = struct
 
   module Show_errors = Flag (struct
     let term =
-      let env = Arg.env_var "ALCOTEST_SHOW_ERRORS" in
+      let env = Cmdliner.Cmd.Env.info "ALCOTEST_SHOW_ERRORS" in
       let doc = "Display the test errors." in
       Arg.(value & flag & info ~env [ "e"; "show-errors" ] ~docv:"" ~doc)
   end)
 
   module Quick_only = Flag (struct
     let term =
-      let env = Arg.env_var "ALCOTEST_QUICK_TESTS" in
+      let env = Cmdliner.Cmd.Env.info "ALCOTEST_QUICK_TESTS" in
       let doc = "Run only the quick tests." in
       Arg.(value & flag & info ~env [ "q"; "quick-tests" ] ~docv:"" ~doc)
   end)
@@ -116,7 +116,7 @@ module Key = struct
     let limit = Arg.conv (limit_parser, limit_printer)
 
     let term =
-      let env = Arg.env_var "ALCOTEST_TAIL_ERRORS" in
+      let env = Cmdliner.Cmd.Env.info "ALCOTEST_TAIL_ERRORS" in
       let doc =
         "Show only the last $(docv) lines of output in case of an error."
       in

--- a/test/e2e/alcotest/failing/unknown_option.expected
+++ b/test/e2e/alcotest/failing/unknown_option.expected
@@ -1,3 +1,3 @@
-unknown_option.<ext>: unknown option `--dry-runn'.
-Usage: unknown_option.<ext> COMMAND ...
-Try `unknown_option.<ext> --help' for more information.
+unknown_option.<ext>: unknown option '--dry-runn'.
+Usage: unknown_option.<ext> [COMMAND] …
+Try 'unknown_option.<ext> --help' for more information.

--- a/test/e2e/gen_dune_rules.ml
+++ b/test/e2e/gen_dune_rules.ml
@@ -66,7 +66,7 @@ let example_rule_stanza ~js ~expect_failure filename =
        (* 1 = failing test, 2 = failed assertion outside runner *)
        "1 2"
       else "0")
-      Cmdliner.Term.exit_status_internal_error
+      Cmdliner.Cmd.Exit.internal_error
   in
   (* Run Alcotest to get *.actual, then pass through the strip_randomness
      sanitiser to get *.processed. *)
@@ -154,9 +154,9 @@ let expect_failure =
   in
   Arg.(value & flag doc)
 
-let term =
-  Term.
-    ( const main $ package $ expect_failure $ libraries $ js,
-      info ~version:"%%VERSION%%" "gen_dune_rules" )
+let cmd =
+  let term = Term.(const main $ package $ expect_failure $ libraries $ js) in
+  let info = Cmd.info ~version:"%%VERSION%%" "gen_dune_rules" in
+  Cmd.v info term
 
-let () = Term.(exit @@ eval term)
+let () = Stdlib.exit (Cmd.eval cmd)


### PR DESCRIPTION
Would be nice to make a point release with this as it would make it possible for me to submit an updated alcotest without disabling tests.