### PR TITLE
Add missing dependency on Unix

### DIFF
--- a/src/alcotest/dune
+++ b/src/alcotest/dune
@@ -1,6 +1,6 @@
 (library
  (public_name alcotest)
- (libraries alcotest.engine astring fmt fmt.tty)
+ (libraries alcotest.engine astring fmt fmt.tty unix)
  (foreign_stubs
   (language c)
   (names alcotest_stubs))


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.