### PR TITLE
Upgrade to async v0.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,9 @@ jobs:
         os:
           - ubuntu-latest
         packages: [ '.' ]
+        runtest: 
+          - true
         ocaml-compiler:
-          - 4.08.x
-          - 4.09.x
-          - 4.10.x
           - 4.11.x
           - 4.12.x
           - 4.13.x
@@ -26,11 +25,31 @@ jobs:
           - os: macos-latest
             ocaml-compiler: 4.13.x
             packages: '.'
+            runtest: true
 
           - os: windows-latest
             ocaml-compiler: 4.13.x
             packages: 'alcotest alcotest-js alcotest-lwt alcotest-mirage'
             opam-local-packages: 'alcotest.opam alcotest-js.opam alcotest-lwt.opam alcotest-mirage.opam'
+            runtest: false
+
+          - os: ubuntu-latest
+            ocaml-compiler: 4.08.x
+            packages: 'alcotest alcotest-js alcotest-lwt alcotest-mirage'
+            opam-local-packages: 'alcotest.opam alcotest-js.opam alcotest-lwt.opam alcotest-mirage.opam'
+            runtest: false
+          
+          - os: ubuntu-latest
+            ocaml-compiler: 4.09.x
+            packages: 'alcotest alcotest-js alcotest-lwt alcotest-mirage'
+            opam-local-packages: 'alcotest.opam alcotest-js.opam alcotest-lwt.opam alcotest-mirage.opam'
+            runtest: false
+          
+          - os: ubuntu-latest
+            ocaml-compiler: 4.10.x
+            packages: 'alcotest alcotest-js alcotest-lwt alcotest-mirage'
+            opam-local-packages: 'alcotest.opam alcotest-js.opam alcotest-lwt.opam alcotest-mirage.opam'
+            runtest: false
 
     runs-on: ${{ matrix.os }}
 
@@ -63,4 +82,5 @@ jobs:
           opam pin add alcotest.dev ./ -n
 
       - run: opam install ${{ matrix.packages }} --with-test --deps-only
-      - run: opam exec -- dune build @install @check @runtest @runtest-js
+      - if: ${{ matrix.runtest }}
+        run: opam exec -- dune build @install @check @runtest @runtest-js

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 
 - Require Cmdliner.1.1.0. (#339, @MisterDA)
 
+- Upgrade to `async>=v0.15.0` (#352, @crackcomm)
+
 ### 1.5.0 (2021-10-09)
 
 - Make Alcotest compatible with `js_of_ocaml.3.11.0`. Users can depend on the

--- a/alcotest-async.opam
+++ b/alcotest-async.opam
@@ -13,13 +13,14 @@ depends: [
   "re" {with-test}
   "fmt" {with-test}
   "cmdliner" {with-test & >= "1.1.0"}
-  "core"
+  "core" {>= "v0.15.0"}
+  "core_unix" {>= "v0.15.0"}
   "base"
   "async_kernel"
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.11.0"}
   "alcotest" {= version}
-  "async_unix" {>= "v0.9.0"}
-  "core_kernel" {>= "v0.9.0"}
+  "async" {>= "v0.15.0"}
+  "async_unix" {>= "v0.15.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -45,13 +45,14 @@ tests to run.
   (re :with-test)
   (fmt :with-test)
   (cmdliner (and :with-test (>= 1.1.0)))
-  core
+  (core (>= v0.15.0))
+  (core_unix (>= v0.15.0))
   base
   async_kernel
-  (ocaml (>= 4.05.0))
+  (ocaml (>= 4.11.0))
   (alcotest (= :version))
-  (async_unix (>= v0.9.0))
-  (core_kernel (>= v0.9.0))))
+  (async (>= v0.15.0))
+  (async_unix (>= v0.15.0))))
 
 (package
  (name alcotest-lwt)

--- a/src/alcotest-async/alcotest_async.ml
+++ b/src/alcotest-async/alcotest_async.ml
@@ -1,5 +1,4 @@
-open Core
-open Async_kernel
+open Async
 open Async_unix
 
 let run_test timeout name fn args =
@@ -8,7 +7,7 @@ let run_test timeout name fn args =
   | `Timeout ->
       Alcotest.fail
         (Printf.sprintf "%s timed out after %s" name
-           (Time.Span.to_string_hum timeout))
+           (Time_unix.Span.to_string_hum timeout))
 
 module Promise = struct
   include Deferred
@@ -25,7 +24,7 @@ module V1 = struct
 
   let test_case_sync n s f = test_case n s (fun x -> Deferred.return (f x))
 
-  let test_case ?(timeout = sec 2.) name s f =
+  let test_case ?(timeout = Time_unix.Span.of_sec 2.) name s f =
     test_case name s (run_test timeout name f)
 end
 

--- a/src/alcotest-async/alcotest_async_intf.ml
+++ b/src/alcotest-async/alcotest_async_intf.ml
@@ -1,12 +1,11 @@
 module type V1 = sig
-  include
-    Alcotest_engine.V1.Cli.S with type return = unit Async_kernel.Deferred.t
+  include Alcotest_engine.V1.Cli.S with type return = unit Async.Deferred.t
 
   val test_case :
-    ?timeout:Core_kernel.Time.Span.t ->
+    ?timeout:Time_unix.Span.t ->
     string ->
     Alcotest.speed_level ->
-    ('a -> unit Async_kernel.Deferred.t) ->
+    ('a -> unit Async.Deferred.t) ->
     'a test_case
 
   val test_case_sync :

--- a/src/alcotest-async/dune
+++ b/src/alcotest-async/dune
@@ -4,8 +4,9 @@
  (libraries
   alcotest.engine
   alcotest
+  async
   async_kernel
   async_unix
   base
   core
-  core_kernel))
+  core_unix.time_unix))

--- a/test/e2e/alcotest/failing/unknown_option-js.expected
+++ b/test/e2e/alcotest/failing/unknown_option-js.expected
@@ -1,3 +1,3 @@
-unknown_option.<ext>: unknown option `--dry-runn'.
-Usage: unknown_option.<ext> COMMAND ...
-Try `unknown_option.<ext> --help' for more information.
+unknown_option.<ext>: unknown option '--dry-runn'.
+Usage: unknown_option.<ext> [COMMAND] …
+Try 'unknown_option.<ext> --help' for more information.


### PR DESCRIPTION
Upgrade to async v0.15.

It might be undesirable but includes `cmdliner >= "1.1.0"` update.

PR submitted in hopes it might save some time for whom it may concern.