### PR TITLE
Basic CI integration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ### dev
 
+- Detect that Alcotest is running in CI and change output accordingly.
+  (#364, @MisterDA)
+
 - Upgrade to `dune >= 3.0`. (#360, @MisterDA)
 
 ### 1.6.0 (2022-06-24)

--- a/src/alcotest-engine/config.ml
+++ b/src/alcotest-engine/config.ml
@@ -343,13 +343,19 @@ let apply_defaults ~default_log_dir : User.t -> t =
        ci;
      } ->
   let open Key in
-  object
+  object (self)
     method and_exit = Option.value ~default:And_exit.default and_exit
     method verbose = Option.value ~default:Verbose.default verbose
     method compact = Option.value ~default:Compact.default compact
     method tail_errors = Option.value ~default:Tail_errors.default tail_errors
     method quick_only = Option.value ~default:Quick_only.default quick_only
-    method show_errors = Option.value ~default:Show_errors.default show_errors
+
+    method show_errors =
+      match (show_errors, self#ci) with
+      | Some show_errors, _ -> show_errors
+      | None, `Disabled -> Show_errors.default
+      | None, _ -> true
+
     method json = Option.value ~default:Json.default json
     method filter = filter
     method log_dir = Option.value ~default:default_log_dir log_dir

--- a/src/alcotest-engine/config_intf.ml
+++ b/src/alcotest-engine/config_intf.ml
@@ -2,6 +2,9 @@ module Types = struct
   type bound = [ `Unlimited | `Limit of int ]
   type filter = name:string -> index:int -> [ `Run | `Skip ]
 
+  type ci = [ `Github_actions | `OCamlci | `Unknown | `Disabled ]
+  (** All supported Continuous Integration (CI) systems. *)
+
   type t =
     < and_exit : bool
     ; verbose : bool
@@ -13,7 +16,8 @@ module Types = struct
     ; filter : filter option
     ; log_dir : string
     ; bail : bool
-    ; record_backtrace : bool >
+    ; record_backtrace : bool
+    ; ci : ci >
 
   type 'a with_options =
     ?and_exit:bool ->
@@ -27,6 +31,7 @@ module Types = struct
     ?log_dir:string ->
     ?bail:bool ->
     ?record_backtrace:bool ->
+    ?ci:ci ->
     'a
 end
 
@@ -45,7 +50,8 @@ module type Config = sig
     (** Like [create], but passes the constructed config to a continuation
         rather than returning directly. *)
 
-    val term : and_exit:bool -> record_backtrace:bool -> t Cmdliner.Term.t
+    val term :
+      and_exit:bool -> record_backtrace:bool -> ci:ci -> t Cmdliner.Term.t
     (** [term] provides a command-line interface for building configs. *)
 
     val ( || ) : t -> t -> t
@@ -56,6 +62,7 @@ module type Config = sig
 
     val and_exit : t -> bool
     val record_backtrace : t -> bool
+    val ci : t -> ci
   end
 
   val apply_defaults : default_log_dir:string -> User.t -> t

--- a/src/alcotest-engine/core.ml
+++ b/src/alcotest-engine/core.ml
@@ -405,9 +405,10 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
   let run' config name (tl : unit test list) = run_with_args' config name () tl
 
   let run_with_args ?and_exit ?verbose ?compact ?tail_errors ?quick_only
-      ?show_errors ?json ?filter ?log_dir ?bail ?record_backtrace =
+      ?show_errors ?json ?filter ?log_dir ?bail ?record_backtrace ?ci =
     Config.User.kcreate run_with_args' ?and_exit ?verbose ?compact ?tail_errors
       ?quick_only ?show_errors ?json ?filter ?log_dir ?bail ?record_backtrace
+      ?ci
 
   let run = Config.User.kcreate run'
 end

--- a/src/alcotest-engine/core.ml
+++ b/src/alcotest-engine/core.ml
@@ -389,12 +389,16 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
       (* Only print inside the concurrency monad *)
       let* () = M.return () in
       let open Fmt in
+      if config#ci = `Github_actions then
+        pr "::group::{%a}\n" Suite.pp_name t.suite;
       pr "Testing %a.@," (Pp.quoted Fmt.(styled `Bold Suite.pp_name)) t.suite;
       pr "@[<v>%a@]"
         (styled `Faint (fun ppf () ->
              pf ppf "This run has ID %a.@,@," (Pp.quoted string) t.run_id))
         ();
-      run_tests t () args
+      let r = run_tests t () args in
+      if config#ci = `Github_actions then pr "::endgroup::\n";
+      r
     in
     match (test_failures, t.config#and_exit) with
     | 0, true -> exit 0

--- a/src/alcotest-engine/core_intf.ml
+++ b/src/alcotest-engine/core_intf.ml
@@ -57,6 +57,7 @@ module V1_types = struct
       ?log_dir:string ->
       ?bail:bool ->
       ?record_backtrace:bool ->
+      ?ci:Config.ci ->
       'a
     (** The various options taken by the tests runners {!run} and
         {!run_with_args}:
@@ -80,7 +81,9 @@ module V1_types = struct
         - [bail] (default [false]). If true, stop running the tests after the
           first failure.
         - [record_backtrace] (default [true]). Enable backtrace recording before
-          beginning testing. *)
+          beginning testing.
+        - [ci] (default auto-detected). Whether to enable specific logging for a
+          CI system. *)
 
     val run : (string -> unit test list -> return) with_options
     val run_with_args : (string -> 'a -> 'a test list -> return) with_options

--- a/test/e2e/dune
+++ b/test/e2e/dune
@@ -1,3 +1,9 @@
+(env
+ (_
+  (env-vars
+   ; Don't run tests as if Alcotest was run in CI
+   (CI false))))
+
 (executable
  (name gen_dune_rules)
  (libraries cmdliner fmt)


### PR DESCRIPTION
This PR attempts to do simple integration from Alcotest to CI systems. For now, Alcotest detects the CI system using the `CI`, `GITHUB_ACTIONS`, or `OCAMLCI` environment variables. As a first showcase of what we can do, when detecting GitHub Actions it will output annotations allowing to fold/unfold a test suite in the web interface. When detecting it's running in CI, Alcotest will also enable the show_errors modes (this can be overridden via the API) so that all failing tests are displayed in the CI (otherwise users would have to fix the failing test, push, and so on, to see the other errors).
I plan to expand the features if this PR is well received. 