### PR TITLE
Best-effort automatic reporting of the location of `Alcotest.check`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ### dev
 
+- Try automatically reporting the location of calls to Alcotest.check.
+  (#366, @MisterDA, review by @TheLortex)
+
 - Detect that Alcotest is running in CI and change output accordingly.
   (#364, @MisterDA)
 

--- a/src/alcotest-engine/callsite_loc.412.ml
+++ b/src/alcotest-engine/callsite_loc.412.ml
@@ -57,3 +57,12 @@ let get ?(__FUNCTION__ = "Alcotest_engine__Test.check") () =
         | None -> None)
     | _ -> None
   else None
+
+let get ?__FUNCTION__ () =
+  let guess =
+    match Sys.getenv "ALCOTEST_SOURCE_CODE_POSITION" with
+    | "" | "false" | "no" | "n" | "0" -> false
+    | "true" | "yes" | "y" | "1" -> true
+    | _ | (exception _) -> true
+  in
+  if guess then get ?__FUNCTION__ () else None

--- a/src/alcotest-engine/callsite_loc.412.ml
+++ b/src/alcotest-engine/callsite_loc.412.ml
@@ -1,0 +1,59 @@
+(*
+ * Copyright (c) 2022 Antonin Décimo <antonin@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** Best-effort reporting of the location of the call to Alcotest.check. *)
+
+let check_caller caller entry =
+  match Printexc.backtrace_slots_of_raw_entry entry with
+  | Some [| slot |] -> (
+      match Printexc.Slot.name slot with
+      | Some name when caller = name -> true
+      | _ -> false)
+  | _ -> false
+
+let get ?(__FUNCTION__ = "Alcotest_engine__Test.check") () =
+  let caller = __FUNCTION__ in
+  let open Printexc in
+  let callstack_depth = 3 (* this function, caller, bound of test *) in
+  let raw_backtrace = get_callstack callstack_depth in
+  let entries = raw_backtrace_entries raw_backtrace in
+  if
+    Array.length entries >= callstack_depth
+    && check_caller caller (Array.unsafe_get entries 1)
+  then
+    match backtrace_slots_of_raw_entry (Array.unsafe_get entries 2) with
+    | Some [| slot |] -> (
+        match Slot.name slot with
+        | Some bound
+          when Alcotest_stdlib_ext.String.(
+                 is_prefix ~affix:"Alcotest_engine__Core." bound
+                 || is_prefix ~affix:"Alcotest_lwt." bound
+                 || is_prefix ~affix:"Alcotest_async." bound
+                 || is_prefix ~affix:"Alcotest_mirage." bound) ->
+            None
+        | Some _ ->
+            Option.map
+              (fun { filename; line_number; start_char; end_char = _ } ->
+                {
+                  Lexing.pos_fname = filename;
+                  pos_lnum = line_number;
+                  pos_bol = 0;
+                  pos_cnum = start_char;
+                })
+              (Slot.location slot)
+        | None -> None)
+    | _ -> None
+  else None

--- a/src/alcotest-engine/cli.ml
+++ b/src/alcotest-engine/cli.ml
@@ -62,7 +62,15 @@ module Make (P : Platform.MAKER) (M : Monad.S) :
     in
     Cmdliner.Cmd.Env.info "OCAMLCI" ~doc
 
-  let envs = [ ci_env; github_action_env; ocamlci_env ]
+  let alcotest_source_code_position =
+    let doc =
+      "Whether Alcotest should guess the source code position of test \
+       failures, if any. Defaults to true, set to a falsy value to disable."
+    in
+    Cmdliner.Cmd.Env.info "ALCOTEST_SOURCE_CODE_POSITION" ~doc
+
+  let envs =
+    [ ci_env; github_action_env; ocamlci_env; alcotest_source_code_position ]
 
   let set_color =
     let env = Cmd.Env.info "ALCOTEST_COLOR" in

--- a/src/alcotest-engine/dune
+++ b/src/alcotest-engine/dune
@@ -1,3 +1,20 @@
+(rule
+ (target callsite_loc.ml)
+ (deps callsite_loc.412.ml)
+ (enabled_if
+  (>= %{ocaml_version} 4.12.0))
+ (action
+  (copy %{deps} %{target})))
+
+(rule
+ (target callsite_loc.ml)
+ (enabled_if
+  (< %{ocaml_version} 4.12.0))
+ (action
+  (write-file
+   %{target}
+   "let get ?__FUNCTION__ () =\n  ignore __FUNCTION__;\n  None\n")))
+
 (library
  (name alcotest_engine)
  (public_name alcotest.engine)

--- a/src/alcotest-engine/test.ml
+++ b/src/alcotest-engine/test.ml
@@ -192,6 +192,10 @@ let check (type a) ?here ?pos (t : a testable) msg (expected : a) (actual : a) =
       ()
     and pp_actual ppf () =
       Fmt.pf ppf "   Received: `%a'" (styled `Red (pp t)) actual
+    and here, pos =
+      match (here, pos) with
+      | None, None -> (Callsite_loc.get (), None)
+      | _ -> (here, pos)
     in
     raise
       (Core.Check_error

--- a/src/alcotest-engine/test.mli
+++ b/src/alcotest-engine/test.mli
@@ -130,7 +130,10 @@ type 'a extra_info =
     descriptive error messages in the case of failure. *)
 
 val check : ('a testable -> string -> 'a -> 'a -> unit) extra_info
-(** Check that two values are equal. *)
+(** Check that two values are equal.
+
+    If [check] isn't in a tail-call position, Alcotest may guess the location of
+    the check. Otherwise, use {!extra_info} to report the location. *)
 
 val check' :
   ('a testable -> msg:string -> expected:'a -> actual:'a -> unit) extra_info

--- a/test/e2e/alcotest/source_code_position/dune
+++ b/test/e2e/alcotest/source_code_position/dune
@@ -1,0 +1,90 @@
+(env
+ (_
+  (env-vars
+   (ALCOTEST_COLOR never)
+   (ALCOTEST_SHOW_ERRORS true))))
+
+(executable
+ (name test_source_code_position)
+ (libraries alcotest astring))
+
+(rule
+ (target with-position.actual)
+ (action
+  (setenv
+   ALCOTEST_SOURCE_CODE_POSITION
+   true
+   (with-accepted-exit-codes
+    (or 1 2 124 125)
+    (with-outputs-to
+     %{target}
+     (run %{dep:test_source_code_position.exe}))))))
+
+(rule
+ (target without-position.actual)
+ (action
+  (setenv
+   ALCOTEST_SOURCE_CODE_POSITION
+   false
+   (with-accepted-exit-codes
+    (or 1 2 124 125)
+    (with-outputs-to
+     %{target}
+     (run %{dep:test_source_code_position.exe}))))))
+
+(rule
+ (target pre-4.12.actual)
+ (action
+  (setenv
+   ALCOTEST_SOURCE_CODE_POSITION
+   true
+   (with-accepted-exit-codes
+    (or 1 2 124 125)
+    (with-outputs-to
+     %{target}
+     (run %{dep:test_source_code_position.exe}))))))
+
+(rule
+ (target with-position.processed)
+ (action
+  (with-outputs-to
+   %{target}
+   (run ../../strip_randomness.exe %{dep:with-position.actual}))))
+
+(rule
+ (target without-position.processed)
+ (action
+  (with-outputs-to
+   %{target}
+   (run ../../strip_randomness.exe %{dep:without-position.actual}))))
+
+(rule
+ (target pre-4.12.processed)
+ (action
+  (with-outputs-to
+   %{target}
+   (run ../../strip_randomness.exe %{dep:pre-4.12.actual}))))
+
+(rule
+ (alias runtest)
+ (package alcotest)
+ (enabled_if
+  (>= %{ocaml_version} 4.12.0))
+ (action
+  (diff with-position.expected with-position.processed)))
+
+(rule
+ (alias runtest)
+ (package alcotest)
+ (enabled_if
+  (>= %{ocaml_version} 4.12.0))
+ (action
+  (diff without-position.expected without-position.processed)))
+
+(rule
+ (alias runtest)
+ (package alcotest)
+ (enabled_if
+  (< %{ocaml_version} 4.12.0))
+ (action
+  (diff pre-4.12.expected pre-4.12.processed)))

--- a/test/e2e/alcotest/source_code_position/pre-4.12.expected
+++ b/test/e2e/alcotest/source_code_position/pre-4.12.expected
@@ -1,0 +1,58 @@
+Testing `First suite'.
+This run has ID `<uuid>'.
+
+  [FAIL]        to_test          0   capitalise.
+  [FAIL]        to_test          1   double all.
+
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [FAIL]        to_test          0   capitalise.                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+ASSERT strings
+FAIL strings
+
+   Expected: `"A"'
+   Received: `"B"'
+
+<stacktrace>
+
+Logs saved to `<build-context>/_build/_tests/<test-dir>/to_test.000.output'.
+ ──────────────────────────────────────────────────────────────────────────────
+
+
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [FAIL]        to_test          1   double all.                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+ASSERT int lists 1
+FAIL int lists 1
+
+   Expected: `[1]'
+   Received: `[2; 2; 4; 6]'
+
+<stacktrace>
+
+Logs saved to `<build-context>/_build/_tests/<test-dir>/to_test.001.output'.
+ ──────────────────────────────────────────────────────────────────────────────
+
+Full test results in `<build-context>/_build/_tests/<test-dir>'.
+2 failures! in <test-duration>s. 2 tests run.Forging ahead regardless!
+
+Testing `Second suite'.
+This run has ID `<uuid>'.
+
+  [OK]          Ωèone          0   Passing test 1.
+  [FAIL]        Ωèone          1   Failing test.
+  [OK]          Ωèone          2   Passing test 2.
+
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [FAIL]        Ωèone          1   Failing test.                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+ASSERT This was never going to work...
+FAIL This was never going to work...
+<stacktrace>
+
+Logs saved to `<build-context>/_build/_tests/<test-dir>/U+03A9U+00E8one.001.output'.
+ ──────────────────────────────────────────────────────────────────────────────
+
+Full test results in `<build-context>/_build/_tests/<test-dir>'.
+1 failure! in <test-duration>s. 3 tests run.
+Fatal error: exception Alcotest_engine__Core.Make(P)(M).Test_error

--- a/test/e2e/alcotest/source_code_position/test_source_code_position.ml
+++ b/test/e2e/alcotest/source_code_position/test_source_code_position.ml
@@ -1,0 +1,60 @@
+(*
+ * Copyright (c) 2022 Antonin Décimo <antonin@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(* A module with functions to test *)
+module To_test = struct
+  let capitalise = Astring.String.Ascii.uppercase
+  let double_all = List.map (fun a -> a + a)
+end
+
+let test_capitalise () =
+  To_test.capitalise "b" |> Alcotest.(check string) "strings" "A";
+  ()
+
+let test_double_all () =
+  To_test.double_all [ 1; 1; 2; 3 ]
+  |> Alcotest.(check (list int)) "int lists 1" [ 1 ];
+  To_test.double_all [ 1; 1; 2; 3 ]
+  |> Alcotest.(check (list int)) "int lists 2" [ 2 ]
+
+let suite1 =
+  [
+    ( "to_test",
+      [
+        ("capitalise", `Quick, test_capitalise);
+        ("double all", `Slow, test_double_all);
+      ] );
+  ]
+
+let suite2 =
+  [
+    ( "Ωèone",
+      [
+        ("Passing test 1", `Quick, fun () -> ());
+        ( "Failing test",
+          `Quick,
+          fun () -> Alcotest.fail "This was never going to work..." );
+        ("Passing test 2", `Quick, fun () -> ());
+      ] );
+  ]
+
+(* Run both suites completely, even if the first contains failures *)
+let () =
+  try Alcotest.run ~and_exit:false "First suite" suite1
+  with Alcotest.Test_error ->
+    Printf.printf "Forging ahead regardless!\n%!";
+    Alcotest.run ~and_exit:false "Second suite" suite2;
+    Printf.printf "Finally done."

--- a/test/e2e/alcotest/source_code_position/with-position.expected
+++ b/test/e2e/alcotest/source_code_position/with-position.expected
@@ -1,0 +1,60 @@
+Testing `First suite'.
+This run has ID `<uuid>'.
+
+  [FAIL]        to_test          0   capitalise.
+  [FAIL]        to_test          1   double all.
+
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [FAIL]        to_test          0   capitalise.                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+ASSERT strings
+File "test/e2e/alcotest/source_code_position/test_source_code_position.ml", line 24, character 2:
+FAIL strings
+
+   Expected: `"A"'
+   Received: `"B"'
+
+<stacktrace>
+
+Logs saved to `<build-context>/_build/_tests/<test-dir>/to_test.000.output'.
+ ──────────────────────────────────────────────────────────────────────────────
+
+
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [FAIL]        to_test          1   double all.                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+ASSERT int lists 1
+File "test/e2e/alcotest/source_code_position/test_source_code_position.ml", line 28, character 2:
+FAIL int lists 1
+
+   Expected: `[1]'
+   Received: `[2; 2; 4; 6]'
+
+<stacktrace>
+
+Logs saved to `<build-context>/_build/_tests/<test-dir>/to_test.001.output'.
+ ──────────────────────────────────────────────────────────────────────────────
+
+Full test results in `<build-context>/_build/_tests/<test-dir>'.
+2 failures! in <test-duration>s. 2 tests run.Forging ahead regardless!
+
+Testing `Second suite'.
+This run has ID `<uuid>'.
+
+  [OK]          Ωèone          0   Passing test 1.
+  [FAIL]        Ωèone          1   Failing test.
+  [OK]          Ωèone          2   Passing test 2.
+
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [FAIL]        Ωèone          1   Failing test.                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+ASSERT This was never going to work...
+FAIL This was never going to work...
+<stacktrace>
+
+Logs saved to `<build-context>/_build/_tests/<test-dir>/U+03A9U+00E8one.001.output'.
+ ──────────────────────────────────────────────────────────────────────────────
+
+Full test results in `<build-context>/_build/_tests/<test-dir>'.
+1 failure! in <test-duration>s. 3 tests run.
+Fatal error: exception Alcotest_engine__Core.Make(P)(M).Test_error

--- a/test/e2e/alcotest/source_code_position/without-position.expected
+++ b/test/e2e/alcotest/source_code_position/without-position.expected
@@ -1,0 +1,58 @@
+Testing `First suite'.
+This run has ID `<uuid>'.
+
+  [FAIL]        to_test          0   capitalise.
+  [FAIL]        to_test          1   double all.
+
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [FAIL]        to_test          0   capitalise.                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+ASSERT strings
+FAIL strings
+
+   Expected: `"A"'
+   Received: `"B"'
+
+<stacktrace>
+
+Logs saved to `<build-context>/_build/_tests/<test-dir>/to_test.000.output'.
+ ──────────────────────────────────────────────────────────────────────────────
+
+
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [FAIL]        to_test          1   double all.                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+ASSERT int lists 1
+FAIL int lists 1
+
+   Expected: `[1]'
+   Received: `[2; 2; 4; 6]'
+
+<stacktrace>
+
+Logs saved to `<build-context>/_build/_tests/<test-dir>/to_test.001.output'.
+ ──────────────────────────────────────────────────────────────────────────────
+
+Full test results in `<build-context>/_build/_tests/<test-dir>'.
+2 failures! in <test-duration>s. 2 tests run.Forging ahead regardless!
+
+Testing `Second suite'.
+This run has ID `<uuid>'.
+
+  [OK]          Ωèone          0   Passing test 1.
+  [FAIL]        Ωèone          1   Failing test.
+  [OK]          Ωèone          2   Passing test 2.
+
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [FAIL]        Ωèone          1   Failing test.                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+ASSERT This was never going to work...
+FAIL This was never going to work...
+<stacktrace>
+
+Logs saved to `<build-context>/_build/_tests/<test-dir>/U+03A9U+00E8one.001.output'.
+ ──────────────────────────────────────────────────────────────────────────────
+
+Full test results in `<build-context>/_build/_tests/<test-dir>'.
+1 failure! in <test-duration>s. 3 tests run.
+Fatal error: exception Alcotest_engine__Core.Make(P)(M).Test_error

--- a/test/e2e/dune
+++ b/test/e2e/dune
@@ -2,7 +2,9 @@
  (_
   (env-vars
    ; Don't run tests as if Alcotest was run in CI
-   (CI false))))
+   (CI false)
+   ; Don't guess source code position for compat with < 4.12.
+   (ALCOTEST_SOURCE_CODE_POSITION false))))
 
 (executable
  (name gen_dune_rules)


### PR DESCRIPTION
This is an attempt of automatically discover the location of calls to `Alcotest.check`, in order to not force the user to pass `~here` or `~pos` arguments. It uses `Printexc.get_callstack`. It's an early attempt that is fragile and requires OCaml 4.11.
The test need to end with the unit value in order to prevent the compiler from optimizing the last call to a tail-call, erasing the location in the process. Is there a way to change Alcotest' code so that this optimization doesn't happen?
A more advanced attempt should probably walk the call stack to find recognizable enclosing functions calls, add regression testing, and make it work (or default to no-op) on pre-4.11. I don't know whether the code is efficient enough.

Try it out with
```shell
dune exec --display=quiet -- examples/bad/bad.exe -e
```

cc @TheLortex 