### PR TITLE
Allow skipping a test case from inside the test case

### DIFF
--- a/src/alcotest-engine/core.ml
+++ b/src/alcotest-engine/core.ml
@@ -19,7 +19,6 @@ open! Import
 open Model
 
 exception Check_error of unit Fmt.t
-
 exception Skip
 
 let () =

--- a/src/alcotest-engine/core.ml
+++ b/src/alcotest-engine/core.ml
@@ -20,6 +20,8 @@ open Model
 
 exception Check_error of unit Fmt.t
 
+exception Skip
+
 let () =
   let print_error =
     (* We instantiate the error print buffer lazily, so as to be sensitive to
@@ -182,6 +184,7 @@ module Make (P : Platform.MAKER) (M : Monad.S) = struct
          | Check_error err ->
              let err = Fmt.(err ++ const string (bt ())) in
              `Error (path, err)
+         | Skip -> `Skip
          | Failure s -> exn path "failure" Fmt.(const string s)
          | Invalid_argument s -> exn path "invalid" Fmt.(const string s)
          | e -> exn path "exception" Fmt.(const exn e))

--- a/src/alcotest-engine/core_intf.ml
+++ b/src/alcotest-engine/core_intf.ml
@@ -106,6 +106,8 @@ end
 module type Core = sig
   exception Check_error of unit Fmt.t
 
+  exception Skip
+
   module V1 : sig
     module type S = V1_types.S
     module type MAKER = V1_types.MAKER

--- a/src/alcotest-engine/core_intf.ml
+++ b/src/alcotest-engine/core_intf.ml
@@ -105,7 +105,6 @@ end
 
 module type Core = sig
   exception Check_error of unit Fmt.t
-
   exception Skip
 
   module V1 : sig

--- a/src/alcotest-engine/test.ml
+++ b/src/alcotest-engine/test.ml
@@ -239,6 +239,5 @@ let check_raises ?here ?pos msg exn f =
             Fmt.pf ppf "%t%a %s: expecting %s, got %s." (pp_location ?here ?pos)
               Pp.tag `Fail msg (Printexc.to_string exn) (Printexc.to_string e))
 
-let skip () = raise (Core.Skip)
-
+let skip () = raise Core.Skip
 let () = at_exit (Format.pp_print_flush Format.err_formatter)

--- a/src/alcotest-engine/test.ml
+++ b/src/alcotest-engine/test.ml
@@ -239,4 +239,6 @@ let check_raises ?here ?pos msg exn f =
             Fmt.pf ppf "%t%a %s: expecting %s, got %s." (pp_location ?here ?pos)
               Pp.tag `Fail msg (Printexc.to_string exn) (Printexc.to_string e))
 
+let skip () = raise (Core.Skip)
+
 let () = at_exit (Format.pp_print_flush Format.err_formatter)

--- a/src/alcotest-engine/test.mli
+++ b/src/alcotest-engine/test.mli
@@ -147,3 +147,6 @@ val failf : (('a, Format.formatter, unit, 'b) format4 -> 'a) extra_info
 
 val check_raises : (string -> exn -> (unit -> unit) -> unit) extra_info
 (** Check that an exception is raised. *)
+
+val skip : unit -> 'a
+(** Skip the current test case. *)

--- a/test/e2e/alcotest/passing/dune.inc
+++ b/test/e2e/alcotest/passing/dune.inc
@@ -19,6 +19,7 @@
    quick_only
    quick_only_regex
    separator_testname
+   skip_in_test
    unicode_testname
    verbose_newlines
  )
@@ -44,6 +45,7 @@
    quick_only
    quick_only_regex
    separator_testname
+   skip_in_test
    unicode_testname
    verbose_newlines
  )
@@ -770,6 +772,44 @@
  (package alcotest)
  (action
    (diff separator_testname-js.expected separator_testname-js.processed)))
+
+(rule
+ (target skip_in_test.actual)
+ (action
+  (with-outputs-to %{target}
+   (with-accepted-exit-codes (or 0 124 125)
+    (run %{dep:skip_in_test.exe})))))
+
+(rule
+ (target skip_in_test.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../../strip_randomness.exe %{dep:skip_in_test.actual}))))
+
+(rule
+ (alias runtest)
+ (package alcotest)
+ (action
+   (diff skip_in_test.expected skip_in_test.processed)))
+
+(rule
+ (target skip_in_test-js.actual)
+ (action
+  (with-outputs-to %{target}
+   (with-accepted-exit-codes (or 0 124 125)
+    (run node %{dep:skip_in_test.bc.js})))))
+
+(rule
+ (target skip_in_test-js.processed)
+ (action
+  (with-outputs-to %{target}
+   (run ../../strip_randomness.exe %{dep:skip_in_test-js.actual}))))
+
+(rule
+ (alias runtest-js)
+ (package alcotest)
+ (action
+   (diff skip_in_test-js.expected skip_in_test-js.processed)))
 
 (rule
  (target unicode_testname.actual)

--- a/test/e2e/alcotest/passing/skip_in_test.expected
+++ b/test/e2e/alcotest/passing/skip_in_test.expected
@@ -1,0 +1,8 @@
+Testing `test/e2e/alcotest/passing/skip_in_test.ml'.
+This run has ID `<uuid>'.
+
+  [OK]          test-a          0   Run test case.
+  [SKIP]        test-a          1   Skip test case.
+
+Full test results in `<build-context>/_build/_tests/<test-dir>'.
+Test Successful in <test-duration>s. 1 test run.

--- a/test/e2e/alcotest/passing/skip_in_test.ml
+++ b/test/e2e/alcotest/passing/skip_in_test.ml
@@ -1,0 +1,11 @@
+let () =
+  let open Alcotest in
+  let id () = () in
+  run __FILE__
+    [
+      ( "test-a",
+        [
+          test_case "Run test case" `Quick id;
+          test_case "Skip test case" `Quick skip;
+        ] );
+    ]


### PR DESCRIPTION
This is useful when you want to perform logic to check whether or not some test case can run in the current environment.

~~~ocaml
let test_only_on_windows () =
  if Sys.os_type <> "Win32" then Alcotest.skip () else ();
  (* actual test code *)
~~~