### PR TITLE
alcotest_stubs.c compile with MSVC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ### dev
 
+- Get `alcotest_stubs.c` to compile with MSVC (#369, @jonahbeckford)
+
 - Try automatically reporting the location of calls to Alcotest.check.
   (#366, @MisterDA, review by @TheLortex)
 

--- a/src/alcotest/alcotest_stubs.c
+++ b/src/alcotest/alcotest_stubs.c
@@ -2,7 +2,9 @@
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #if OCAML_VERSION < 41200
 #define Val_none Val_int(0)


### PR DESCRIPTION
`unistd.h` is not present in Windows SDK (MSVC) and usually unnecessary.

Before:

```
========= [TROUBLESHOOTING] alcotest-3480-337052.out ===========

[alcotest-3480-337052.out] File "src/alcotest/dune", line 6, characters 9-23:
[alcotest-3480-337052.out] 6 |   (names alcotest_stubs))
[alcotest-3480-337052.out]              ^^^^^^^^^^^^^^
[alcotest-3480-337052.out] (cd _build/default/src/alcotest && "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.25.28610\bin\HostX64\x64\cl.exe" -nologo -O2 -Gy- -MD -D_CRT_SECURE_NO_DEPRECATE -nologo -O2 -Gy- -MD -I D:/.opam/dkml/lib/ocaml -I D:\.opam\dkml\lib\astring -I D:\.opam\dkml\lib\fmt -I ../alcotest-engine /Foalcotest_stubs.obj -c alcotest_stubs.c)
[alcotest-3480-337052.out] alcotest_stubs.c
[alcotest-3480-337052.out] alcotest_stubs.c(4): fatal error C1083: Cannot open include file: 'unistd.h': No such file or directory
```