### PR TITLE
Fix reporting terminal dimensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,18 @@
 
 - Add `match_raises`, a generalized version of `check_raises`
   (#88, #386, @JoanThibault)
-- Update JaneStreet core and async to v0.16 (#390 @tmcgilchrist)  
+
+- Update JaneStreet core and async to v0.16 (#390 @tmcgilchrist)
+
+- Fix division by zero when size of the terminal is incorrectly
+  reported as zero. (fix #356, #381, @MisterDA)
+
+- Enable terminal size reporting on macOS and Windows. Also report the
+  terminal size even when the test is run buffered by Dune.
+  (#381, @MisterDA)
+
+- Allow overriding the number of columns with `ALCOTEST_COLUMNS` env
+  var. (#322, #381, @MisterDA)
 
 ### 1.7.0 (2023-02-24)
 

--- a/alcotest-help.txt
+++ b/alcotest-help.txt
@@ -77,6 +77,11 @@ ENVIRONMENT
        ALCOTEST_COLOR
            See option --color.
 
+       ALCOTEST_COLUMNS
+           Number of columns after which Alcotest truncates or splits written
+           lines. Default is to auto-detect using the terminal's dimensions,
+           or fallback to 80 columns.
+
        ALCOTEST_COMPACT
            See option --compact.
 

--- a/src/alcotest-engine/cli.ml
+++ b/src/alcotest-engine/cli.ml
@@ -69,8 +69,22 @@ module Make (P : Platform.MAKER) (M : Monad.S) :
     in
     Cmdliner.Cmd.Env.info "ALCOTEST_SOURCE_CODE_POSITION" ~doc
 
+  let alcotest_columns =
+    let doc =
+      "Number of columns after which Alcotest truncates or splits written \
+       lines. Default is to auto-detect using the terminal's dimensions, or \
+       fallback to 80 columns."
+    in
+    Cmdliner.Cmd.Env.info "ALCOTEST_COLUMNS" ~doc
+
   let envs =
-    [ ci_env; github_action_env; ocamlci_env; alcotest_source_code_position ]
+    [
+      ci_env;
+      github_action_env;
+      ocamlci_env;
+      alcotest_source_code_position;
+      alcotest_columns;
+    ]
 
   let set_color =
     let env = Cmd.Env.info "ALCOTEST_COLOR" in

--- a/src/alcotest-stdlib-ext/alcotest_stdlib_ext.ml
+++ b/src/alcotest-stdlib-ext/alcotest_stdlib_ext.ml
@@ -86,6 +86,7 @@ end
 module Option = struct
   let is_some = function Some _ -> true | None -> false
   let map f = function Some x -> Some (f x) | None -> None
+  let bind o f = match o with Some o -> f o | None -> None
 
   let get_exn = function
     | Some x -> x

--- a/src/alcotest-stdlib-ext/alcotest_stdlib_ext.mli
+++ b/src/alcotest-stdlib-ext/alcotest_stdlib_ext.mli
@@ -42,6 +42,7 @@ end
 
 module Option : sig
   val map : ('a -> 'b) -> 'a option -> 'b option
+  val bind : 'a option -> ('a -> 'b option) -> 'b option
   val is_some : _ option -> bool
   val get_exn : 'a option -> 'a
   val value : default:'a -> 'a option -> 'a

--- a/src/alcotest/alcotest.ml
+++ b/src/alcotest/alcotest.ml
@@ -77,8 +77,8 @@ module Unix_platform (M : Alcotest_engine.Monad.S) = struct
     if Sys.win32 then None
     else
       match Terminal.get_dimensions () with
-      | Some { columns; _ } -> Some columns
-      | None -> None
+      | Some { columns; _ } when columns > 0 -> Some columns
+      | _ -> None
 
   external before_test :
     output:out_channel -> stdout:out_channel -> stderr:out_channel -> unit

--- a/src/alcotest/alcotest.ml
+++ b/src/alcotest/alcotest.ml
@@ -74,11 +74,9 @@ module Unix_platform (M : Alcotest_engine.Monad.S) = struct
   let stdout_isatty () = Unix.(isatty stdout)
 
   let stdout_columns () =
-    if Sys.win32 then None
-    else
-      match Terminal.get_dimensions () with
-      | Some { columns; _ } when columns > 0 -> Some columns
-      | _ -> None
+    match Terminal.get_dimensions () with
+    | Some { columns; _ } when columns > 0 -> Some columns
+    | _ -> None
 
   external before_test :
     output:out_channel -> stdout:out_channel -> stderr:out_channel -> unit

--- a/src/alcotest/alcotest.ml
+++ b/src/alcotest/alcotest.ml
@@ -74,9 +74,12 @@ module Unix_platform (M : Alcotest_engine.Monad.S) = struct
   let stdout_isatty () = Unix.(isatty stdout)
 
   let stdout_columns () =
-    match Terminal.get_dimensions () with
-    | Some { columns; _ } when columns > 0 -> Some columns
-    | _ -> None
+    match Option.bind (Sys.getenv_opt "ALCOTEST_COLUMNS") int_of_string_opt with
+    | Some columns when columns > 0 -> Some columns
+    | _ -> (
+        match Terminal.get_dimensions () with
+        | Some { columns; _ } when columns > 0 -> Some columns
+        | _ -> None)
 
   external before_test :
     output:out_channel -> stdout:out_channel -> stderr:out_channel -> unit

--- a/src/alcotest/alcotest_stubs.c
+++ b/src/alcotest/alcotest_stubs.c
@@ -55,13 +55,20 @@ CAMLprim value ocaml_alcotest_get_terminal_dimensions(value unit)
 #elif defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
 #include <unistd.h>
 #include <sys/ioctl.h>
+#include <fcntl.h>
 
 CAMLprim value ocaml_alcotest_get_terminal_dimensions(value unit)
 {
 	CAMLparam1(unit);
 	CAMLlocal2(result, pair);
 	struct winsize ws;
-	int z = ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws);
+	int fd = open("/dev/tty", O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+	if (fd < 0) {
+		result = Val_none;
+		CAMLreturn(result);
+	}
+	int z = ioctl(fd, TIOCGWINSZ, &ws);
+        close(fd);
 	if (z == 0)
 	{
 		pair = caml_alloc_tuple(2);

--- a/src/alcotest/alcotest_stubs.c
+++ b/src/alcotest/alcotest_stubs.c
@@ -69,7 +69,7 @@ CAMLprim value ocaml_alcotest_get_terminal_dimensions(value unit)
 	}
 	int z = ioctl(fd, TIOCGWINSZ, &ws);
         close(fd);
-	if (z == 0)
+	if (z != -1)
 	{
 		pair = caml_alloc_tuple(2);
 		Store_field(pair, 0, Val_int(ws.ws_row));

--- a/src/alcotest/alcotest_stubs.c
+++ b/src/alcotest/alcotest_stubs.c
@@ -1,10 +1,12 @@
 #include <caml/version.h>
+
+#if OCAML_VERSION < 50000
+#define CAML_NAME_SPACE
+#endif
+
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 
 #if OCAML_VERSION < 41200
 #define Val_none Val_int(0)
@@ -19,20 +21,14 @@ static value caml_alloc_some(value v)
 }
 #endif
 
-// Detect platform
-#if defined(_WIN32)
-#define OCAML_ALCOTEST_WINDOWS
-#elif defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
-#if defined(_POSIX_VERSION)
-#define OCAML_ALCOTEST_POSIX
-#endif
-#endif
-
 // Windows support
-#if defined(OCAML_ALCOTEST_WINDOWS)
+#if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #define VC_EXTRALEAN
 #include <windows.h>
+#if !defined(_MSC_VER)
+#include <unistd.h>
+#endif
 
 CAMLprim value ocaml_alcotest_get_terminal_dimensions(value unit)
 {
@@ -56,8 +52,8 @@ CAMLprim value ocaml_alcotest_get_terminal_dimensions(value unit)
 	CAMLreturn(result);
 }
 
-// POSIX support
-#elif defined(OCAML_ALCOTEST_POSIX)
+#elif defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+#include <unistd.h>
 #include <sys/ioctl.h>
 
 CAMLprim value ocaml_alcotest_get_terminal_dimensions(value unit)

--- a/test/e2e/dune
+++ b/test/e2e/dune
@@ -4,7 +4,9 @@
    ; Don't run tests as if Alcotest was run in CI
    (CI false)
    ; Don't guess source code position for compat with < 4.12.
-   (ALCOTEST_SOURCE_CODE_POSITION false))))
+   (ALCOTEST_SOURCE_CODE_POSITION false)
+   ; Set to 80 columns for output reproducibility
+   (ALCOTEST_COLUMNS 80))))
 
 (executable
  (name gen_dune_rules)


### PR DESCRIPTION
- Fix division by zero when size of the terminal is incorrectly reported as zero. (fix #356, #381, @MisterDA)

- Enable terminal size reporting on macOS and Windows. Also report the terminal size even when the test is run buffered by Dune.
  (#381, @MisterDA)

- Allow overriding the number of columns with `ALCOTEST_COLUMNS` env var. (#322, #381, @MisterDA)
  
My intent was to use a bigger default than 80 columns when the CI is detected. Sadly, this would seem to require too big of a refactoring to communicate the default size to the `Pp` module, which is also why I haven't made the number of columns configurable programmatically, and exposed it only via an environment variable to fix reproducibility issues for the Unix platform.
Oddly enough, communicating the bounds to the `Format` module with `Format.set_margin` hides the first `[OK]`, `[FAIL]`, etc tag. I've haven't dug why.
I've tested that this on macOS, Windows FreeBSD, and Linux.