### PR TITLE
Set min version of cmdliner to 1.1.1

### DIFF
--- a/alcotest-async.opam
+++ b/alcotest-async.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.0"}
   "re" {with-test}
   "fmt" {with-test}
-  "cmdliner" {with-test & >= "1.1.0"}
+  "cmdliner" {with-test & >= "1.1.1"}
   "core" {>= "v0.15.0"}
   "core_unix" {>= "v0.15.0"}
   "base"

--- a/alcotest-js.opam
+++ b/alcotest-js.opam
@@ -15,7 +15,7 @@ depends: [
   "alcotest" {= version}
   "js_of_ocaml-compiler" {>= "3.11.0"}
   "fmt" {with-test & >= "0.8.7"}
-  "cmdliner" {with-test & >= "1.1.0"}
+  "cmdliner" {with-test & >= "1.1.1"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/mirage/alcotest.git"

--- a/alcotest-lwt.opam
+++ b/alcotest-lwt.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
   "dune" {>= "3.0"}
   "re" {with-test}
-  "cmdliner" {with-test & >= "1.1.0"}
+  "cmdliner" {with-test & >= "1.1.1"}
   "fmt"
   "ocaml" {>= "4.05.0"}
   "alcotest" {= version}

--- a/alcotest-mirage.opam
+++ b/alcotest-mirage.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
   "dune" {>= "3.0"}
   "re" {with-test}
-  "cmdliner" {with-test & >= "1.1.0"}
+  "cmdliner" {with-test & >= "1.1.1"}
   "fmt"
   "ocaml" {>= "4.05.0"}
   "alcotest" {= version}

--- a/alcotest.opam
+++ b/alcotest.opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "fmt" {>= "0.8.7"}
   "astring"
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.1"}
   "re" {>= "1.7.2"}
   "stdlib-shims"
   "uutf" {>= "1.0.1"}

--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@ tests to run.
   (ocaml (>= 4.05.0))
   (fmt (>= 0.8.7))
   astring
-  (cmdliner (>= 1.1.0))
+  (cmdliner (>= 1.1.1))
   (re (>= 1.7.2))
   stdlib-shims
   (uutf (>= 1.0.1))
@@ -44,7 +44,7 @@ tests to run.
  (depends
   (re :with-test)
   (fmt :with-test)
-  (cmdliner (and :with-test (>= 1.1.0)))
+  (cmdliner (and :with-test (>= 1.1.1)))
   (core (>= v0.15.0))
   (core_unix (>= v0.15.0))
   base
@@ -61,7 +61,7 @@ tests to run.
  (documentation "https://mirage.github.io/alcotest")
  (depends
   (re :with-test)
-  (cmdliner (and :with-test (>= 1.1.0)))
+  (cmdliner (and :with-test (>= 1.1.1)))
   fmt
   (ocaml (>= 4.05.0))
   (alcotest (= :version))
@@ -75,7 +75,7 @@ tests to run.
  (documentation "https://mirage.github.io/alcotest")
  (depends
   (re :with-test)
-  (cmdliner (and :with-test (>= 1.1.0)))
+  (cmdliner (and :with-test (>= 1.1.1)))
   fmt
   (ocaml (>= 4.05.0))
   (alcotest (= :version))
@@ -94,4 +94,4 @@ tests to run.
   (alcotest (= :version))
   (js_of_ocaml-compiler (>= 3.11.0))
   (fmt (and :with-test (>= 0.8.7)))
-  (cmdliner (and :with-test (>= 1.1.0)))))
+  (cmdliner (and :with-test (>= 1.1.1)))))


### PR DESCRIPTION
cmdliner.1.1.1 removed trailing whitespace from help messages. Building this with cmdliner < 1.1.1 causes the comparison with alcotest-help.txt to fail due to whitespace differences.