### PR TITLE
Bump to OCaml 4.08 and cmdliner 1.2.0

### DIFF
--- a/alcotest-async.opam
+++ b/alcotest-async.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.0"}
   "re" {with-test}
   "fmt" {with-test}
-  "cmdliner" {with-test & >= "1.1.1"}
+  "cmdliner" {with-test & >= "1.2.0"}
   "core" {>= "v0.15.0"}
   "core_unix" {>= "v0.15.0"}
   "base"

--- a/alcotest-help.txt
+++ b/alcotest-help.txt
@@ -58,7 +58,7 @@ COMMON OPTIONS
            whenever the TERM env var is dumb or undefined.
 
 EXIT STATUS
-       test.exe exits with the following status:
+       test.exe exits with:
 
        0   on success.
 

--- a/alcotest-js.opam
+++ b/alcotest-js.opam
@@ -15,7 +15,7 @@ depends: [
   "alcotest" {= version}
   "js_of_ocaml-compiler" {>= "3.11.0"}
   "fmt" {with-test & >= "0.8.7"}
-  "cmdliner" {with-test & >= "1.1.1"}
+  "cmdliner" {with-test & >= "1.2.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/mirage/alcotest.git"

--- a/alcotest-lwt.opam
+++ b/alcotest-lwt.opam
@@ -11,9 +11,9 @@ bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
   "dune" {>= "3.0"}
   "re" {with-test}
-  "cmdliner" {with-test & >= "1.1.1"}
+  "cmdliner" {with-test & >= "1.2.0"}
   "fmt"
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.08.0"}
   "alcotest" {= version}
   "lwt"
   "logs"

--- a/alcotest-mirage.opam
+++ b/alcotest-mirage.opam
@@ -11,9 +11,9 @@ bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
   "dune" {>= "3.0"}
   "re" {with-test}
-  "cmdliner" {with-test & >= "1.1.1"}
+  "cmdliner" {with-test & >= "1.2.0"}
   "fmt"
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.08.0"}
   "alcotest" {= version}
   "mirage-clock" {>= "2.0.0"}
   "duration"

--- a/alcotest.opam
+++ b/alcotest.opam
@@ -20,10 +20,10 @@ doc: "https://mirage.github.io/alcotest"
 bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.08"}
   "fmt" {>= "0.8.7"}
   "astring"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.2.0"}
   "re" {>= "1.7.2"}
   "stdlib-shims"
   "uutf" {>= "1.0.1"}

--- a/dune-project
+++ b/dune-project
@@ -24,10 +24,10 @@ inspect), with a simple (yet expressive) query language to select the
 tests to run.
 ")
  (depends
-  (ocaml (>= 4.05.0))
+  (ocaml (>= 4.08))
   (fmt (>= 0.8.7))
   astring
-  (cmdliner (>= 1.1.1))
+  (cmdliner (>= 1.2.0))
   (re (>= 1.7.2))
   stdlib-shims
   (uutf (>= 1.0.1))
@@ -44,7 +44,7 @@ tests to run.
  (depends
   (re :with-test)
   (fmt :with-test)
-  (cmdliner (and :with-test (>= 1.1.1)))
+  (cmdliner (and :with-test (>= 1.2.0)))
   (core (>= v0.15.0))
   (core_unix (>= v0.15.0))
   base
@@ -61,9 +61,9 @@ tests to run.
  (documentation "https://mirage.github.io/alcotest")
  (depends
   (re :with-test)
-  (cmdliner (and :with-test (>= 1.1.1)))
+  (cmdliner (and :with-test (>= 1.2.0)))
   fmt
-  (ocaml (>= 4.05.0))
+  (ocaml (>= 4.08.0))
   (alcotest (= :version))
   lwt
   logs))
@@ -75,9 +75,9 @@ tests to run.
  (documentation "https://mirage.github.io/alcotest")
  (depends
   (re :with-test)
-  (cmdliner (and :with-test (>= 1.1.1)))
+  (cmdliner (and :with-test (>= 1.2.0)))
   fmt
-  (ocaml (>= 4.05.0))
+  (ocaml (>= 4.08.0))
   (alcotest (= :version))
   (mirage-clock (>= 2.0.0))
   duration
@@ -94,4 +94,4 @@ tests to run.
   (alcotest (= :version))
   (js_of_ocaml-compiler (>= 3.11.0))
   (fmt (and :with-test (>= 0.8.7)))
-  (cmdliner (and :with-test (>= 1.1.1)))))
+  (cmdliner (and :with-test (>= 1.2.0)))))


### PR DESCRIPTION
Cmdliner 1.2.0 provides Windows and help fixes.
It requires at least OCaml 4.08.