### PR TITLE
Update JaneStreet core and async.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,8 @@ jobs:
         runtest:
           - true
         ocaml-compiler:
-          - 4.12.x
-          - 4.13.x
           - 4.14.x
+          - 5.0.x
         include:
           - os: macos-latest
             ocaml-compiler: 4.14.x
@@ -56,6 +55,19 @@ jobs:
             packages: 'alcotest alcotest-js alcotest-lwt alcotest-mirage'
             opam-local-packages: 'alcotest.opam alcotest-js.opam alcotest-lwt.opam alcotest-mirage.opam'
             runtest: false
+ 
+          - os: ubuntu-latest
+            ocaml-compiler: 4.12.x
+            packages: 'alcotest alcotest-js alcotest-lwt alcotest-mirage'
+            opam-local-packages: 'alcotest.opam alcotest-js.opam alcotest-lwt.opam alcotest-mirage.opam'
+            runtest: false
+ 
+          - os: ubuntu-latest
+            ocaml-compiler: 4.13.x
+            packages: 'alcotest alcotest-js alcotest-lwt alcotest-mirage'
+            opam-local-packages: 'alcotest.opam alcotest-js.opam alcotest-lwt.opam alcotest-mirage.opam'
+            runtest: false
+
 
 
     runs-on: ${{ matrix.os }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 - Add `match_raises`, a generalized version of `check_raises`
   (#88, #386, @JoanThibault)
+- Update JaneStreet core and async to v0.16 (#390 @tmcgilchrist)  
 
 ### 1.7.0 (2023-02-24)
 

--- a/alcotest-async.opam
+++ b/alcotest-async.opam
@@ -13,14 +13,14 @@ depends: [
   "re" {with-test}
   "fmt" {with-test}
   "cmdliner" {with-test & >= "1.2.0"}
-  "core" {>= "v0.15.0"}
-  "core_unix" {>= "v0.15.0"}
+  "core" {>= "v0.16.0"}
+  "core_unix" {>= "v0.16.0"}
   "base"
   "async_kernel"
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.14.0"}
   "alcotest" {= version}
-  "async" {>= "v0.15.0"}
-  "async_unix" {>= "v0.15.0"}
+  "async" {>= "v0.16.0"}
+  "async_unix" {>= "v0.16.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -45,14 +45,14 @@ tests to run.
   (re :with-test)
   (fmt :with-test)
   (cmdliner (and :with-test (>= 1.2.0)))
-  (core (>= v0.15.0))
-  (core_unix (>= v0.15.0))
+  (core (>= v0.16.0))
+  (core_unix (>= v0.16.0))
   base
   async_kernel
-  (ocaml (>= 4.11.0))
+  (ocaml (>= 4.14.0))
   (alcotest (= :version))
-  (async (>= v0.15.0))
-  (async_unix (>= v0.15.0))))
+  (async (>= v0.16.0))
+  (async_unix (>= v0.16.0))))
 
 (package
  (name alcotest-lwt)

--- a/src/alcotest-async/alcotest_async.ml
+++ b/src/alcotest-async/alcotest_async.ml
@@ -7,7 +7,7 @@ let run_test timeout name fn args =
   | `Timeout ->
       Alcotest.fail
         (Printf.sprintf "%s timed out after %s" name
-           (Time_unix.Span.to_string_hum timeout))
+           (Time_float_unix.Span.to_string_hum timeout))
 
 module Promise = struct
   include Deferred
@@ -24,7 +24,7 @@ module V1 = struct
 
   let test_case_sync n s f = test_case n s (fun x -> Deferred.return (f x))
 
-  let test_case ?(timeout = Time_unix.Span.of_sec 2.) name s f =
+  let test_case ?(timeout = Time_float_unix.Span.of_sec 2.) name s f =
     test_case name s (run_test timeout name f)
 end
 

--- a/src/alcotest-async/alcotest_async_intf.ml
+++ b/src/alcotest-async/alcotest_async_intf.ml
@@ -2,7 +2,7 @@ module type V1 = sig
   include Alcotest_engine.V1.Cli.S with type return = unit Async.Deferred.t
 
   val test_case :
-    ?timeout:Time_unix.Span.t ->
+    ?timeout:Time_float_unix.Span.t ->
     string ->
     Alcotest.speed_level ->
     ('a -> unit Async.Deferred.t) ->

--- a/src/alcotest-async/dune
+++ b/src/alcotest-async/dune
@@ -9,4 +9,4 @@
   async_unix
   base
   core
-  core_unix.time_unix))
+  core_unix.time_float_unix))


### PR DESCRIPTION
Fixes deprecation against core_unix.time_unix and bumps the OCaml version to 4.14. 