### PR TITLE
Recognize opam-repo-ci

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 - Add `match_raises`, a generalized version of `check_raises`
   (#88, #386, @JoanThibault)
-- Update JaneStreet core and async to v0.16 (#390 @tmcgilchrist)  
+- Update JaneStreet core and async to v0.16 (#390 @tmcgilchrist)
+- Recognize opam-repo-ci. (#394, @MisterDA)
 
 ### 1.7.0 (2023-02-24)
 

--- a/alcotest-help.txt
+++ b/alcotest-help.txt
@@ -107,3 +107,7 @@ ENVIRONMENT
            Whether Alcotest is running in OCaml-CI, if set to 'true'. Display
            tests errors.
 
+       OPAM_REPO_CI
+           Whether Alcotest is running in opam-repo-ci, if set to 'true'.
+           Display tests errors.
+

--- a/src/alcotest-engine/cli.ml
+++ b/src/alcotest-engine/cli.ml
@@ -62,6 +62,15 @@ module Make (P : Platform.MAKER) (M : Monad.S) :
     in
     Cmdliner.Cmd.Env.info "OCAMLCI" ~doc
 
+  let opam_repo_ci_env =
+    let doc =
+      Printf.sprintf
+        "Whether Alcotest is running in opam-repo-ci, if set to %s. Display \
+         tests errors."
+        (Arg.doc_quote "true")
+    in
+    Cmdliner.Cmd.Env.info "OPAM_REPO_CI" ~doc
+
   let alcotest_source_code_position =
     let doc =
       "Whether Alcotest should guess the source code position of test \
@@ -70,7 +79,13 @@ module Make (P : Platform.MAKER) (M : Monad.S) :
     Cmdliner.Cmd.Env.info "ALCOTEST_SOURCE_CODE_POSITION" ~doc
 
   let envs =
-    [ ci_env; github_action_env; ocamlci_env; alcotest_source_code_position ]
+    [
+      ci_env;
+      github_action_env;
+      ocamlci_env;
+      opam_repo_ci_env;
+      alcotest_source_code_position;
+    ]
 
   let set_color =
     let env = Cmd.Env.info "ALCOTEST_COLOR" in

--- a/src/alcotest-engine/config_intf.ml
+++ b/src/alcotest-engine/config_intf.ml
@@ -2,7 +2,7 @@ module Types = struct
   type bound = [ `Unlimited | `Limit of int ]
   type filter = name:string -> index:int -> [ `Run | `Skip ]
 
-  type ci = [ `Github_actions | `OCamlci | `Unknown | `Disabled ]
+  type ci = [ `Github_actions | `OCamlci | `Opam_repo_ci | `Unknown | `Disabled ]
   (** All supported Continuous Integration (CI) systems. *)
 
   type t =


### PR DESCRIPTION
Recognize Alcotest is running in opam-repo-ci if the `OPAM_REPO_CI` env var is set to `"true"`, and display all the tests (failures) by default.