### PR TITLE
Open Windows console handle to retreive dimensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 
 - Enable terminal size reporting on macOS and Windows. Also report the
   terminal size even when the test is run buffered by Dune.
-  (#381, @MisterDA)
+  (#381, #396, @MisterDA)
 
 - Allow overriding the number of columns with `ALCOTEST_COLUMNS` env
   var. (#322, #381, @MisterDA)

--- a/src/alcotest/alcotest_stubs.c
+++ b/src/alcotest/alcotest_stubs.c
@@ -35,8 +35,16 @@ CAMLprim value ocaml_alcotest_get_terminal_dimensions(value unit)
 	CAMLparam1(unit);
 	CAMLlocal2(result, pair);
 
+	HANDLE console = CreateFileW(L"CONOUT$", GENERIC_READ|GENERIC_WRITE,
+		FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
+		OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	HANDLE handle = console == INVALID_HANDLE_VALUE ?
+		GetStdHandle(STD_OUTPUT_HANDLE) : console;
 	CONSOLE_SCREEN_BUFFER_INFO csbi;
-	int success = GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
+	int success = GetConsoleScreenBufferInfo(handle, &csbi);
+	if (console != INVALID_HANDLE_VALUE)
+		CloseHandle(console);
+
 	if (success)
 	{
 		pair = caml_alloc_tuple(2);


### PR DESCRIPTION
If stdout is redirected on Windows, the dimensions of the terminal won't be correctly retrieved. Open the console instead, using the special filename `CONOUT$`, and ask the dimensions of this handle. Keep a fallback to stdout if the console can't be opened, because you can never be too cautious with this OS.

(this is akin to opening `/dev/tty` on Unix).

https://learn.microsoft.com/en-us/windows/console/console-handles