### PR TITLE
Don't detect ocaml-ci specifically, improve CI detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
 - Allow overriding the number of columns with `ALCOTEST_COLUMNS` env
   var. (#322, #381, @MisterDA)
 
+- Stop detecting ocamlci specifically, since there's nothing specific
+  about it. Simply use the `CI` env var to detect CIs.
+  (#397, @MisterDA)
+
 ### 1.7.0 (2023-02-24)
 
 - Allow skipping a test case from inside the test case (#368, @apeschar)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,8 @@
   var. (#322, #381, @MisterDA)
 
 - Stop detecting ocamlci specifically, since there's nothing specific
-  about it. Simply use the `CI` env var to detect CIs.
+  about it. Simply use the `CI` env var to detect CIs. Improve CI
+  detection.
   (#397, @MisterDA)
 
 ### 1.7.0 (2023-02-24)

--- a/alcotest-help.txt
+++ b/alcotest-help.txt
@@ -108,7 +108,3 @@ ENVIRONMENT
            Whether Alcotest is running in GitHub Actions, if set to 'true'.
            Display tests errors and outputs GitHub Actions annotations.
 
-       OCAMLCI
-           Whether Alcotest is running in OCaml-CI, if set to 'true'. Display
-           tests errors.
-

--- a/src/alcotest-engine/cli.ml
+++ b/src/alcotest-engine/cli.ml
@@ -44,7 +44,7 @@ module Make (P : Platform.MAKER) (M : Monad.S) :
     in
     Cmdliner.Cmd.Env.info "CI" ~doc
 
-  let github_action_env =
+  let github_actions_env =
     let doc =
       Printf.sprintf
         "Whether Alcotest is running in GitHub Actions, if set to %s. Display \
@@ -52,15 +52,6 @@ module Make (P : Platform.MAKER) (M : Monad.S) :
         (Arg.doc_quote "true")
     in
     Cmdliner.Cmd.Env.info "GITHUB_ACTIONS" ~doc
-
-  let ocamlci_env =
-    let doc =
-      Printf.sprintf
-        "Whether Alcotest is running in OCaml-CI, if set to %s. Display tests \
-         errors."
-        (Arg.doc_quote "true")
-    in
-    Cmdliner.Cmd.Env.info "OCAMLCI" ~doc
 
   let alcotest_source_code_position =
     let doc =
@@ -80,8 +71,7 @@ module Make (P : Platform.MAKER) (M : Monad.S) :
   let envs =
     [
       ci_env;
-      github_action_env;
-      ocamlci_env;
+      github_actions_env;
       alcotest_source_code_position;
       alcotest_columns;
     ]

--- a/src/alcotest-engine/config.ml
+++ b/src/alcotest-engine/config.ml
@@ -54,7 +54,7 @@ module Key = struct
     let default =
       let getenv var =
         match Sys.getenv var with
-        | "true" -> true
+        | "true" | "True" -> true
         | _ | (exception Not_found) -> false
       in
       let ci = getenv "CI" and github_actions = getenv "GITHUB_ACTIONS" in

--- a/src/alcotest-engine/config.ml
+++ b/src/alcotest-engine/config.ml
@@ -52,23 +52,15 @@ module Key = struct
     type t = ci
 
     let default =
-      let ci =
-        match Sys.getenv "CI" with
-        | "true" -> true
-        | _ | (exception Not_found) -> false
-      and github_actions =
-        match Sys.getenv "GITHUB_ACTIONS" with
-        | "true" -> true
-        | _ | (exception Not_found) -> false
-      and ocamlci =
-        match Sys.getenv "OCAMLCI" with
+      let getenv var =
+        match Sys.getenv var with
         | "true" -> true
         | _ | (exception Not_found) -> false
       in
-      match (ci, github_actions, ocamlci) with
-      | true, true, false -> `Github_actions
-      | true, false, true -> `OCamlci
-      | true, false, false -> `Unknown
+      let ci = getenv "CI" and github_actions = getenv "GITHUB_ACTIONS" in
+      match (ci, github_actions) with
+      | true, true -> `Github_actions
+      | true, false -> `Unknown
       | _ -> `Disabled
   end
 

--- a/src/alcotest-engine/config_intf.ml
+++ b/src/alcotest-engine/config_intf.ml
@@ -2,7 +2,7 @@ module Types = struct
   type bound = [ `Unlimited | `Limit of int ]
   type filter = name:string -> index:int -> [ `Run | `Skip ]
 
-  type ci = [ `Github_actions | `OCamlci | `Unknown | `Disabled ]
+  type ci = [ `Github_actions | `Unknown | `Disabled ]
   (** All supported Continuous Integration (CI) systems. *)
 
   type t =


### PR DESCRIPTION
In light of recent discussions (see #394 #395), I think that simply using the `CI` environment variables to enable the `show_errors` behavior is sufficient, if there's nothing more to do to integrate the CI with Alcotest.
Turns out, we were already doing that with the `` `Unkown `` variant.

AppVeyor uses `CI=True` (capitalized), support that too. Couldn't find if Jenkins defines a specific variable.