### PR TITLE
Fix alcotest's own tests when using OCaml 5.2

### DIFF
--- a/test/e2e/strip_randomness.ml
+++ b/test/e2e/strip_randomness.ml
@@ -80,8 +80,11 @@ let stacktrace_replace =
     ^^ rep1 print
     ^^ str "\""
     ^^ opt (str " (inlined)")
-    ^^ str ", line "
-    ^^ rep1 digit
+    ^^ alt
+         [
+           seq [str ", line "; rep1 digit];
+           seq [str ", lines "; rep1 digit; char '-'; rep1 digit];
+         ]
     ^^ str ", characters "
     ^^ rep1 digit
     ^^ str "-"


### PR DESCRIPTION
The backtrace format changed in 5.2.

Otherwise `dune test` fails with:
```
#=== ERROR while compiling alcotest.1.7.0 =====================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/alcotest.1.7.0
# command              ~/.opam/5.2/bin/dune build -p alcotest -j 1 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/alcotest-1572-265f5d.env
# output-file          ~/.opam/log/alcotest-1572-265f5d.out
### output ###
# (cd _build/default/examples && ./floats.exe)
# Testing `Float tests'.
# This run has ID `0GQT2QHE'.
# 
#   [OK]          Edge cases            0   NaN.
#   [OK]          Edge cases            1   ∞.
#   [OK]          Other floats          0   others.
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/alcotest.1.7.0/_build/default/examples/_build/_tests/Float tests'.
# Test Successful in 0.000s. 3 tests run.
# (cd _build/default/examples && ./simple.exe)
# Testing `Utils'.
# This run has ID `9SIA8X8A'.
# 
#   [OK]          string-case            0   Lower case.
#   [OK]          string-case            1   Capitalization.
#   [OK]          string-concat          0   String mashing.
#   [OK]          list-concat            0   List mashing.
# 
# Full test results in `~/.opam/5.2/.opam-switch/build/alcotest.1.7.0/_build/default/examples/_build/_tests/Utils'.
# Test Successful in 0.000s. 4 tests run.
# File "test/e2e/alcotest/source_code_position/with-position.expected", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/e2e/alcotest/source_code_position/with-position.expected _build/default/test/e2e/alcotest/source_code_position/with-position.processed
# diff --git a/_build/default/test/e2e/alcotest/source_code_position/with-position.expected b/_build/default/test/e2e/alcotest/source_code_position/with-position.processed
# index 34697b9..0bb5731 100644
# --- a/_build/default/test/e2e/alcotest/source_code_position/with-position.expected
# +++ b/_build/default/test/e2e/alcotest/source_code_position/with-position.processed
# @@ -14,7 +14,7 @@ FAIL strings
#     Expected: `"A"'
#     Received: `"B"'
#  
# -<stacktrace>
# +Raised at Alcotest_engine__Test.check in file "src/alcotest-engine/test.ml", lines 200-210, characters 4-19
```