### PR TITLE
testable for seq and contramap (for testable)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### unreleased
+
+- Add `seq`, a testable for `Seq.t` and `contramap` (#412 @xvw)
+
 ### 1.8.0 (2024-07-25)
 
 - Add `match_raises`, a generalized version of `check_raises`

--- a/src/alcotest-engine/test.ml
+++ b/src/alcotest-engine/test.ml
@@ -42,7 +42,7 @@ let testable (type a) (pp : a Fmt.t) (equal : a -> a -> bool) : a testable =
   end in
   (module M)
 
-let contramap f t =
+let map f t =
   let pp ppf = (Fmt.using f (pp t)) ppf and equal a b = equal t (f a) (f b) in
   testable pp equal
 

--- a/src/alcotest-engine/test.ml
+++ b/src/alcotest-engine/test.ml
@@ -42,6 +42,11 @@ let testable (type a) (pp : a Fmt.t) (equal : a -> a -> bool) : a testable =
   end in
   (module M)
 
+let contramap f t =
+  let pp ppf = (Fmt.using f (pp t)) ppf
+  and equal a b = (equal t (f a) (f b)) in
+  testable pp equal
+
 let int32 = testable Fmt.int32 ( = )
 let int64 = testable Fmt.int64 ( = )
 let int = testable Fmt.int ( = )

--- a/src/alcotest-engine/test.ml
+++ b/src/alcotest-engine/test.ml
@@ -43,8 +43,7 @@ let testable (type a) (pp : a Fmt.t) (equal : a -> a -> bool) : a testable =
   (module M)
 
 let contramap f t =
-  let pp ppf = (Fmt.using f (pp t)) ppf
-  and equal a b = (equal t (f a) (f b)) in
+  let pp ppf = (Fmt.using f (pp t)) ppf and equal a b = equal t (f a) (f b) in
   testable pp equal
 
 let int32 = testable Fmt.int32 ( = )
@@ -82,6 +81,15 @@ let list e =
     | _ -> false
   in
   testable (Fmt.Dump.list (pp e)) eq
+
+let seq e =
+  let rec eq s1 s2 =
+    match (Seq.uncons s1, Seq.uncons s2) with
+    | Some (x, xs), Some (y, ys) -> equal e x y && eq xs ys
+    | None, None -> true
+    | _ -> false
+  in
+  testable (Fmt.Dump.seq (pp e)) eq
 
 let slist (type a) (a : a testable) compare =
   let l = list a in

--- a/src/alcotest-engine/test.ml
+++ b/src/alcotest-engine/test.ml
@@ -84,9 +84,9 @@ let list e =
 
 let seq e =
   let rec eq s1 s2 =
-    match (Seq.uncons s1, Seq.uncons s2) with
-    | Some (x, xs), Some (y, ys) -> equal e x y && eq xs ys
-    | None, None -> true
+    match (s1 (), s2 ()) with
+    | Seq.Cons (x, xs), Seq.Cons (y, ys) -> equal e x y && eq xs ys
+    | Nil, Nil -> true
     | _ -> false
   in
   testable (Fmt.Dump.seq (pp e)) eq

--- a/src/alcotest-engine/test.mli
+++ b/src/alcotest-engine/test.mli
@@ -107,6 +107,10 @@ val neg : 'a testable -> 'a testable
 (** [neg t] is [t]'s negation: it is [true] when [t] is [false] and it is
     [false] when [t] is [true]. *)
 
+val contramap : ('b -> 'a) -> 'a testable -> 'b testable
+(** [contramap f t] lift a ['a testable] to a ['b testable],
+    converting ['b] to ['a]. *)
+
 (** {1 Assertion functions}
 
     Functions for asserting various properties within unit-tests. A failing

--- a/src/alcotest-engine/test.mli
+++ b/src/alcotest-engine/test.mli
@@ -110,9 +110,8 @@ val neg : 'a testable -> 'a testable
 (** [neg t] is [t]'s negation: it is [true] when [t] is [false] and it is
     [false] when [t] is [true]. *)
 
-val contramap : ('b -> 'a) -> 'a testable -> 'b testable
-(** [contramap f t] lift a ['a testable] to a ['b testable],
-    converting ['b] to ['a]. *)
+val map : ('b -> 'a) -> 'a testable -> 'b testable
+(** [map f t] lift a ['a testable] to a ['b testable], converting ['b] to ['a]. *)
 
 (** {1 Assertion functions}
 

--- a/src/alcotest-engine/test.mli
+++ b/src/alcotest-engine/test.mli
@@ -74,6 +74,9 @@ val unit : unit testable
 val list : 'a testable -> 'a list testable
 (** [list t] tests lists of [t]s. *)
 
+val seq : 'a testable -> 'a Seq.t testable
+(** [seq t] tests sequence of [t]s. *)
+
 val slist : 'a testable -> ('a -> 'a -> int) -> 'a list testable
 (** [slist t comp] tests sorted lists of [t]s. The list are sorted using [comp]. *)
 


### PR DESCRIPTION
This PR adds:
- `seq` (to produces `'a Seq.t testable`) Because the `Seq.t` type has become very common in the standard library
- `contramap` which allows you to go from an `'a testable` to a `'b testable` giving a function from `b -> 'a` (because a testable is a contravariant functor). I have often found the function useful for implementing testables _quickly_ when there is a trivial transformation.