### PR TITLE
no longer rely on joo_global_object

### DIFF
--- a/src/alcotest/runtime.js
+++ b/src/alcotest/runtime.js
@@ -23,7 +23,7 @@ function alcotest_after_test (vstdout, vstderr){
 
 //Provides: ocaml_alcotest_get_terminal_dimensions
 function ocaml_alcotest_get_terminal_dimensions(unit) {
-  var p = joo_global_object.process
+  var p = globalThis.process
   if(p && p.stdout && p.stdout.columns && p.stdout.rows) {
     return [0, [0, p.stdout.rows, p.stdout.columns]];
   }


### PR DESCRIPTION
It's deprecated and will result in a warning with the next release of jsoo