### PR TITLE
Add missing conf-npm to alcotest-js

### DIFF
--- a/alcotest-js.opam
+++ b/alcotest-js.opam
@@ -16,6 +16,7 @@ depends: [
   "js_of_ocaml-compiler" {>= "3.11.0"}
   "fmt" {with-test & >= "0.8.7"}
   "cmdliner" {with-test & >= "1.2.0"}
+  "conf-npm" {with-test}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/mirage/alcotest.git"

--- a/dune-project
+++ b/dune-project
@@ -95,4 +95,5 @@ tests to run.
   (alcotest (= :version))
   (js_of_ocaml-compiler (>= 3.11.0))
   (fmt (and :with-test (>= 0.8.7)))
-  (cmdliner (and :with-test (>= 1.2.0)))))
+  (cmdliner (and :with-test (>= 1.2.0)))
+  (conf-npm :with-test)))


### PR DESCRIPTION
This adds a missing `conf-npm with-test` dependency to `alcotest-js` and regenerates the opam file.

Spotted and fixed on the opam-repo in https://github.com/ocaml/opam-repository/pull/28669