### PR TITLE
Add WASM support.

### DIFF
--- a/alcotest-async.opam
+++ b/alcotest-async.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/mirage/alcotest"
 doc: "https://mirage.github.io/alcotest"
 bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.17"}
   "re" {with-test}
   "fmt" {with-test}
   "cmdliner" {with-test & >= "1.2.0"}

--- a/alcotest-js.opam
+++ b/alcotest-js.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mirage/alcotest"
 doc: "https://mirage.github.io/alcotest"
 bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.17"}
   "alcotest" {= version}
   "js_of_ocaml-compiler" {>= "3.11.0"}
   "fmt" {with-test & >= "0.8.7"}

--- a/alcotest-lwt.opam
+++ b/alcotest-lwt.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/mirage/alcotest"
 doc: "https://mirage.github.io/alcotest"
 bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.17"}
   "re" {with-test}
   "cmdliner" {with-test & >= "1.2.0"}
   "fmt"

--- a/alcotest-mirage.opam
+++ b/alcotest-mirage.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/mirage/alcotest"
 doc: "https://mirage.github.io/alcotest"
 bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.17"}
   "re" {with-test}
   "cmdliner" {with-test & >= "1.2.0"}
   "fmt"

--- a/alcotest.opam
+++ b/alcotest.opam
@@ -19,7 +19,7 @@ homepage: "https://github.com/mirage/alcotest"
 doc: "https://mirage.github.io/alcotest"
 bug-reports: "https://github.com/mirage/alcotest/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.17"}
   "ocaml" {>= "4.08"}
   "fmt" {>= "0.8.7"}
   "astring"

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.0)
+(lang dune 3.17)
 (implicit_transitive_deps false)
 (generate_opam_files true)
 

--- a/src/alcotest/dune
+++ b/src/alcotest/dune
@@ -6,4 +6,6 @@
   (names alcotest_stubs))
  (js_of_ocaml
   (javascript_files runtime.js))
+ (wasm_of_ocaml
+  (wasm_files runtime.wat))
  (preprocess future_syntax))

--- a/src/alcotest/runtime.wat
+++ b/src/alcotest/runtime.wat
@@ -1,0 +1,19 @@
+;; WASM stubs for alcotest runtime.
+;; Adapted from https://github.com/mirage/alcotest/blob/main/src/alcotest/runtime.js
+;; Channel redirection is not available in WASM, so before/after are no-ops.
+
+(module
+   (func (export "alcotest_before_test")
+      (param $voutput (ref eq)) (param $vstdout (ref eq)) (param $vstderr (ref eq))
+      (result (ref eq))
+      (ref.i31 (i32.const 0)))
+
+   (func (export "alcotest_after_test")
+      (param $vstdout (ref eq)) (param $vstderr (ref eq))
+      (result (ref eq))
+      (ref.i31 (i32.const 0)))
+
+   (func (export "ocaml_alcotest_get_terminal_dimensions")
+      (param (ref eq)) (result (ref eq))
+      (ref.i31 (i32.const 0)))
+)


### PR DESCRIPTION
This MR adds the required stubs for wasm_of_ocaml. They are simple no-ops.